### PR TITLE
Add quality preset selector and config sync for remote mode

### DIFF
--- a/backend/app/services/nowcast/remote_client.py
+++ b/backend/app/services/nowcast/remote_client.py
@@ -56,6 +56,7 @@ class NowcastRemoteClient:
         self._enabled = self._config.get_bool("nowcast_enabled", False)
         self._remote_url = self._config.get("nowcast_remote_url", "").rstrip("/")
         self._api_key = self._config.get("nowcast_remote_api_key", "")
+        self._quality_preset = self._config.get("nowcast_quality_preset", "economy")
 
     def is_enabled(self) -> bool:
         return self._enabled and bool(self._remote_url)
@@ -88,17 +89,35 @@ class NowcastRemoteClient:
             await asyncio.sleep(PUSH_INTERVAL)
 
     async def _tick(self) -> None:
-        """Single iteration: push readings, poll for results."""
+        """Single iteration: push readings, sync config, poll for results."""
         old_key = self._api_key
+        old_preset = getattr(self, "_quality_preset", "")
         self.reload_config()
         if not self.is_enabled():
             return
         # Update auth header if key changed
         if self._api_key != old_key and self._client:
             self._client.headers["X-API-Key"] = self._api_key if self._api_key else ""
+        # Sync preset to remote server if changed
+        if self._quality_preset != old_preset:
+            await self._sync_config({"nowcast_quality_preset": self._quality_preset})
 
         await self._push_readings()
         await self._poll_nowcast()
+
+    async def _sync_config(self, updates: dict) -> None:
+        """Push config updates to the remote server."""
+        try:
+            resp = await self._client.post(
+                f"{self._remote_url}/api/config",
+                json=updates,
+            )
+            if resp.status_code == 200:
+                logger.info("Synced config to remote: %s", updates)
+            else:
+                logger.warning("Config sync failed: %d", resp.status_code)
+        except httpx.HTTPError as exc:
+            logger.warning("Config sync failed: %s", exc)
 
     async def _push_readings(self) -> None:
         """Push new sensor readings to the remote endpoint."""

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -2758,7 +2758,7 @@ export default function Settings() {
           )}
         </div>
 
-        {/* Remote mode — endpoint URL, API key, and info */}
+        {/* Remote mode — endpoint URL, API key, preset, and info */}
         {String(val("nowcast_mode") || "local") === "remote" && (<>
           <div style={fieldGroup}>
             <label style={labelStyle}>
@@ -2775,9 +2775,27 @@ export default function Settings() {
               onChange={(e) => updateField("nowcast_remote_api_key", e.target.value)}
             />
           </div>
+          <div style={fieldGroup}>
+            <label style={labelStyle}>
+              Quality Preset
+              <span style={{ fontSize: "11px", color: "var(--color-text-muted)", display: "block", marginTop: "2px" }}>
+                Controls which AI model is used. During severe weather, the system automatically
+                uses the best available model regardless of this setting.
+              </span>
+            </label>
+            <select
+              style={{ ...selectStyle, maxWidth: "480px" }}
+              value={String(val("nowcast_quality_preset") || "economy")}
+              onChange={(e) => updateField("nowcast_quality_preset", e.target.value)}
+            >
+              <option value="economy">Economy — lowest cost, Haiku for routine, Sonnet for severe</option>
+              <option value="standard">Standard — Haiku for routine, Opus for warnings</option>
+              <option value="premium">Premium — Sonnet always, Opus for severe weather</option>
+            </select>
+          </div>
           <p style={{ fontSize: "12px", color: "var(--color-text-muted)", fontFamily: "var(--font-body)", margin: "0", lineHeight: 1.5 }}>
-            In remote mode, all nowcast engine settings (model, data sources, radar, nearby stations) are
-            configured on the remote kanfei-nowcast server. Only the endpoint URL and API key are needed here.
+            Data sources, radar, and nearby stations are configured on the remote server.
+            The quality preset and update interval are the only engine settings managed here.
           </p>
         </>)}
 
@@ -2806,23 +2824,30 @@ export default function Settings() {
           />
         </div>
 
+        <div style={fieldGroup}>
+          <label style={labelStyle}>
+            Quality Preset
+            <span style={{ fontSize: "11px", color: "var(--color-text-muted)", display: "block", marginTop: "2px" }}>
+              Controls which AI model is used for routine weather. During severe weather,
+              the system automatically escalates to the best available model.
+            </span>
+          </label>
+          <select
+            style={{ ...selectStyle, maxWidth: "480px" }}
+            value={String(val("nowcast_quality_preset") || "economy")}
+            onChange={(e) => updateField("nowcast_quality_preset", e.target.value)}
+          >
+            <option value="economy">Economy — Haiku for routine, Sonnet for severe</option>
+            <option value="standard">Standard — Haiku for routine, Opus for warnings</option>
+            <option value="premium">Premium — Sonnet always, Opus for severe weather</option>
+          </select>
+        </div>
+
         <div style={{
           display: "grid",
           gridTemplateColumns: isMobile ? "1fr" : "1fr 1fr",
           gap: isMobile ? "12px" : "16px",
         }}>
-          <div style={fieldGroup}>
-            <label style={labelStyle}>Model</label>
-            <select
-              style={selectStyle}
-              value={String(val("nowcast_model") || "claude-haiku-4-5-20251001")}
-              onChange={(e) => updateField("nowcast_model", e.target.value)}
-            >
-              <option value="claude-haiku-4-5-20251001">Haiku 4.5 (fastest, lowest cost)</option>
-              <option value="claude-sonnet-4-5-20250929">Sonnet 4.5 (better reasoning)</option>
-            </select>
-          </div>
-
           <div style={fieldGroup}>
             <label style={labelStyle}>Update Interval</label>
             <select


### PR DESCRIPTION
## Summary

Builds on the SaaS auth PR (merged). Replaces the raw model name dropdown with customer-friendly quality presets, adds config sync to remote server, and improves auth error surfacing.

### Changes

- **Settings UI (both modes)**: Quality preset selector replaces model dropdown
  - Economy — lowest cost, Haiku routine, Sonnet for severe
  - Standard — Haiku routine, Opus for warnings
  - Premium — Sonnet always, Opus for severe weather
- **Remote client**: syncs preset selection to remote server via `POST /api/config` when changed
- **Remote client**: sends `X-API-Key` header, handles 401/403/429 with clear log messages
- **Nowcast status**: `GET /api/nowcast/status` endpoint exposes service state and auth errors
- **Nowcast page**: contextual error messages (auth failures, waiting for data, not enabled)
- **Remote mode info text**: updated to reflect preset and interval as managed settings

### How it works

- Customer selects a preset in Settings
- In remote mode, the preset is synced to the server via `POST /api/config`
- The server-side preset resolver (in kanfei-nowcast) maps the preset to concrete models based on weather conditions and the customer's subscription tier
- During severe weather, the system overrides to the best model regardless of preset

## Test plan

- [x] TypeScript compiles clean
- [x] Python compiles clean
- [x] Preset selector appears in both local and remote mode Settings
- [x] Preset change syncs to remote server (confirmed in both client and server logs)
- [x] Auth key accepted — readings push and nowcast data flows end-to-end
- [x] 401 logged when key is missing
- [x] Nowcast page shows contextual message when enabled but no data
- [x] Settings fields align correctly in remote mode (grid alignment fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)