### PR TITLE
Refactor: SensorSnapshot to SI, eliminate display-unit round-tripping

### DIFF
--- a/backend/app/protocol/base.py
+++ b/backend/app/protocol/base.py
@@ -18,11 +18,12 @@ from typing import Optional
 class SensorSnapshot:
     """Canonical sensor data returned by every driver's poll() method.
 
-    All values use standard units.  Fields are None when the sensor is
-    absent or the reading is invalid.
+    All values use SI units.  The driver is responsible for converting
+    from its native format to SI before returning.  Everything downstream
+    (poller, calculations, DB storage) assumes SI.
     """
 
-    # Temperatures (°F)
+    # Temperatures (°C)
     inside_temp: Optional[float] = None
     outside_temp: Optional[float] = None
 
@@ -31,28 +32,28 @@ class SensorSnapshot:
     outside_humidity: Optional[int] = None
 
     # Wind
-    wind_speed: Optional[int] = None        # mph
+    wind_speed: Optional[float] = None      # m/s
     wind_direction: Optional[int] = None    # degrees 0-359
-    wind_gust: Optional[int] = None         # mph
+    wind_gust: Optional[float] = None       # m/s
 
-    # Barometer (inHg, sea-level corrected)
+    # Barometer (hPa, sea-level corrected)
     barometer: Optional[float] = None
 
     # Rain
-    rain_rate: Optional[float] = None       # in/hr
-    rain_daily: Optional[float] = None      # inches (since midnight)
-    rain_yearly: Optional[float] = None     # inches (since Jan 1)
+    rain_rate: Optional[float] = None       # mm/hr
+    rain_daily: Optional[float] = None      # mm (since midnight)
+    rain_yearly: Optional[float] = None     # mm (since Jan 1)
 
     # Solar / UV
     solar_radiation: Optional[int] = None   # W/m²
     uv_index: Optional[float] = None        # index
 
     # Soil / Leaf
-    soil_temp: Optional[float] = None       # °F
+    soil_temp: Optional[float] = None       # °C
     soil_moisture: Optional[int] = None     # centibars
     leaf_wetness: Optional[int] = None      # 0-15
 
-    # Evapotranspiration (inches)
+    # Evapotranspiration (mm)
     et_daily: Optional[float] = None
 
     # Vendor-specific fields that don't map to the standard schema

--- a/backend/app/protocol/link_driver.py
+++ b/backend/app/protocol/link_driver.py
@@ -989,39 +989,38 @@ class LinkDriver(StationDriver):
             daily_clicks if daily_clicks is not None else reading.rain_total
         )
 
-        # SensorReading is now in SI units (tenths °C, tenths hPa, tenths m/s,
-        # tenths mm) after _to_si() in loop_packet.py. Convert to SensorSnapshot
-        # display floats (°F, inHg, mph, inches) for the broadcast pipeline.
+        # SensorReading is in SI (tenths °C, tenths hPa, tenths m/s, tenths mm)
+        # after _to_si() in loop_packet.py. Divide by 10 to get SI floats.
         return SensorSnapshot(
             inside_temp=(
-                reading.inside_temp / 10.0 * 9 / 5 + 32
+                reading.inside_temp / 10.0
                 if reading.inside_temp is not None else None
             ),
             outside_temp=(
-                reading.outside_temp / 10.0 * 9 / 5 + 32
+                reading.outside_temp / 10.0
                 if reading.outside_temp is not None else None
             ),
             inside_humidity=reading.inside_humidity,
             outside_humidity=reading.outside_humidity,
             wind_speed=(
-                round(reading.wind_speed / 10.0 * 2.23694)
+                reading.wind_speed / 10.0
                 if reading.wind_speed is not None else None
             ),
             wind_direction=reading.wind_direction,
             barometer=(
-                reading.barometer / 10.0 / 33.8639
+                reading.barometer / 10.0
                 if reading.barometer is not None else None
             ),
             rain_daily=(
-                rain_daily_clicks / 10.0 / 25.4
+                rain_daily_clicks / 10.0
                 if rain_daily_clicks is not None else None
             ),
             rain_rate=(
-                reading.rain_rate / 10.0 / 25.4
+                reading.rain_rate / 10.0
                 if reading.rain_rate is not None else None
             ),
             rain_yearly=(
-                yearly_clicks / 10.0 / 25.4
+                yearly_clicks / 10.0
                 if yearly_clicks is not None else None
             ),
             solar_radiation=reading.solar_radiation,
@@ -1030,7 +1029,7 @@ class LinkDriver(StationDriver):
                 if reading.uv_index is not None else None
             ),
             soil_temp=(
-                reading.soil_temp / 10.0 * 9 / 5 + 32
+                reading.soil_temp / 10.0
                 if reading.soil_temp is not None else None
             ),
             leaf_wetness=reading.leaf_wetness,

--- a/backend/app/services/poller.py
+++ b/backend/app/services/poller.py
@@ -182,19 +182,19 @@ class Poller:
             snapshot.rain_rate = self._rain_rate_in_per_hr
             self._last_rain_daily = snapshot.rain_daily
 
-        # Convert SensorSnapshot display floats (°F, inHg, mph) to SI for
-        # the calculation functions (tenths °C, tenths hPa, tenths m/s).
+        # SensorSnapshot is now SI (°C, hPa, m/s, mm).
+        # Scale to tenths for calculation functions and DB storage.
         temp_tenths_c = (
-            round((snapshot.outside_temp - 32) * 5 / 9 * 10)
+            round(snapshot.outside_temp * 10)
             if snapshot.outside_temp is not None else None
         )
         hum = snapshot.outside_humidity
         baro_tenths_hpa = (
-            round(snapshot.barometer * 33.8639 * 10)
+            round(snapshot.barometer * 10)
             if snapshot.barometer is not None else None
         )
         wind_tenths_ms = (
-            round(snapshot.wind_speed * 4.4704)
+            round(snapshot.wind_speed * 10)
             if snapshot.wind_speed is not None else None
         )
 
@@ -221,42 +221,41 @@ class Poller:
         # Pressure trend from recent history
         trend = await self._get_pressure_trend()
 
-        # Store to database in SI units (tenths °C, tenths hPa, tenths m/s, tenths mm).
-        # Convert SensorSnapshot display floats (°F, inHg, mph, inches) to SI integers.
+        # Store to database — SensorSnapshot is SI, DB wants tenths (×10).
         db = SessionLocal()
         try:
             model = SensorReadingModel(
                 timestamp=datetime.now(timezone.utc),
                 station_type=self._station_type_code,
                 inside_temp=(
-                    round((snapshot.inside_temp - 32) * 5 / 9 * 10)
+                    round(snapshot.inside_temp * 10)
                     if snapshot.inside_temp is not None else None
                 ),
                 outside_temp=(
-                    round((snapshot.outside_temp - 32) * 5 / 9 * 10)
+                    round(snapshot.outside_temp * 10)
                     if snapshot.outside_temp is not None else None
                 ),
                 inside_humidity=snapshot.inside_humidity,
                 outside_humidity=snapshot.outside_humidity,
                 wind_speed=(
-                    round(snapshot.wind_speed * 4.4704)
+                    round(snapshot.wind_speed * 10)
                     if snapshot.wind_speed is not None else None
                 ),
                 wind_direction=snapshot.wind_direction,
                 barometer=(
-                    round(snapshot.barometer * 33.8639 * 10)
+                    round(snapshot.barometer * 10)
                     if snapshot.barometer is not None else None
                 ),
                 rain_total=(
-                    round(snapshot.rain_daily * 25.4 * 10)
+                    round(snapshot.rain_daily * 10)
                     if snapshot.rain_daily is not None else None
                 ),
                 rain_rate=(
-                    round(snapshot.rain_rate * 25.4 * 10)
+                    round(snapshot.rain_rate * 10)
                     if snapshot.rain_rate is not None else None
                 ),
                 rain_yearly=(
-                    round(snapshot.rain_yearly * 25.4 * 10)
+                    round(snapshot.rain_yearly * 10)
                     if snapshot.rain_yearly is not None else None
                 ),
                 solar_radiation=snapshot.solar_radiation,
@@ -392,59 +391,82 @@ class Poller:
         trend: Optional[str],
         extremes: Optional[dict] = None,
     ) -> dict:
-        """Convert a SensorSnapshot to a JSON-serializable dict for WebSocket.
+        """Convert a SensorSnapshot (SI) to a JSON-serializable dict for WebSocket.
 
         Format matches the REST /api/current response so the frontend
         can use the same CurrentConditions type for both sources.
 
-        Derived values (hi, dp, wc, fl, theta) remain in native tenths-F /
-        tenths-K for compatibility with the existing API contract.
+        This is the ONLY place SI → display conversion happens for live data.
+        Derived values (hi, dp, wc, fl, theta) are in tenths °C / tenths K.
         """
-        def temp_f(tenths: Optional[int]) -> Optional[float]:
-            """Convert derived value from tenths-F to float F."""
-            return tenths / 10.0 if tenths is not None else None
+        from ..utils.units import (
+            si_temp_to_display_f,
+            si_pressure_to_display_inhg,
+            si_wind_to_display_mph,
+            si_rain_to_display_in,
+        )
+
+        def _temp_f(c: Optional[float]) -> Optional[float]:
+            """°C float → °F display float."""
+            return round(c * 9 / 5 + 32, 1) if c is not None else None
+
+        def _derived_f(tenths_c: Optional[int]) -> Optional[float]:
+            """Derived value tenths °C → °F display float."""
+            return si_temp_to_display_f(tenths_c) if tenths_c is not None else None
+
+        def _baro(hpa: Optional[float]) -> Optional[float]:
+            """hPa float → inHg display float."""
+            return round(hpa / 33.8639, 2) if hpa is not None else None
+
+        def _wind(ms: Optional[float]) -> Optional[int]:
+            """m/s float → mph display int."""
+            return round(ms * 2.23694) if ms is not None else None
+
+        def _rain(mm: Optional[float]) -> Optional[float]:
+            """mm float → inches display float."""
+            return round(mm / 25.4, 2) if mm is not None else None
 
         return {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "station_type": self.driver.station_name,
             "temperature": {
-                "inside": {"value": snapshot.inside_temp, "unit": "F"},
-                "outside": {"value": snapshot.outside_temp, "unit": "F"},
+                "inside": {"value": _temp_f(snapshot.inside_temp), "unit": "F"},
+                "outside": {"value": _temp_f(snapshot.outside_temp), "unit": "F"},
             },
             "humidity": {
                 "inside": {"value": snapshot.inside_humidity, "unit": "%"},
                 "outside": {"value": snapshot.outside_humidity, "unit": "%"},
             },
             "wind": {
-                "speed": {"value": snapshot.wind_speed, "unit": "mph"},
+                "speed": {"value": _wind(snapshot.wind_speed), "unit": "mph"},
                 "direction": {"value": snapshot.wind_direction, "unit": "°"},
                 "cardinal": self._cardinal(snapshot.wind_direction),
             },
             "barometer": {
-                "value": snapshot.barometer,
+                "value": _baro(snapshot.barometer),
                 "unit": "inHg",
                 "trend": trend,
             },
             "rain": {
                 "daily": (
-                    {"value": round(snapshot.rain_daily, 2), "unit": "in"}
+                    {"value": _rain(snapshot.rain_daily), "unit": "in"}
                     if snapshot.rain_daily is not None else None
                 ),
                 "yearly": (
-                    {"value": round(snapshot.rain_yearly, 2), "unit": "in"}
+                    {"value": _rain(snapshot.rain_yearly), "unit": "in"}
                     if snapshot.rain_yearly is not None else None
                 ),
                 "rate": (
-                    {"value": round(snapshot.rain_rate, 2), "unit": "in/hr"}
+                    {"value": _rain(snapshot.rain_rate), "unit": "in/hr"}
                     if snapshot.rain_rate is not None else None
                 ),
                 "yesterday": {"value": round(self.rain_yesterday, 2), "unit": "in"},
             },
             "derived": {
-                "heat_index": {"value": temp_f(hi), "unit": "F"},
-                "dew_point": {"value": temp_f(dp), "unit": "F"},
-                "wind_chill": {"value": temp_f(wc), "unit": "F"},
-                "feels_like": {"value": temp_f(fl), "unit": "F"},
+                "heat_index": {"value": _derived_f(hi), "unit": "F"},
+                "dew_point": {"value": _derived_f(dp), "unit": "F"},
+                "wind_chill": {"value": _derived_f(wc), "unit": "F"},
+                "feels_like": {"value": _derived_f(fl), "unit": "F"},
                 "theta_e": {"value": theta / 10.0 if theta is not None else None, "unit": "K"},
             },
             "solar_radiation": (


### PR DESCRIPTION
## Summary

Closes #39. `SensorSnapshot` is now SI. Drivers convert from hardware-native to SI, everything downstream assumes SI. No more display-unit round-tripping.

## Before (3 conversions)
```
LOOP bytes → _to_si() (SI ints) → LinkDriver (SI → display floats)
→ SensorSnapshot (°F/inHg/mph/in) → Poller (display → SI for DB + calcs)
```

## After (1 conversion in driver + 1 at broadcast)
```
LOOP bytes → _to_si() (SI ints) → LinkDriver (÷10 = SI floats)
→ SensorSnapshot (°C/hPa/m·s⁻¹/mm) → Poller (×10 for DB, SI → display at broadcast only)
```

## Changes

| File | What changed |
|------|-------------|
| `base.py` | SensorSnapshot fields: °C, hPa, m/s, mm (was °F, inHg, mph, in) |
| `link_driver.py` | Divides SI tenths by 10 (was converting to display) |
| `poller.py` | Stores `×10` directly to DB. Calls calculations with `×10`. Converts SI → display only in `_snapshot_to_dict()` |

## Impact on new drivers
A new driver (Ecowitt, Tempest, Ambient) now just needs to output SI `SensorSnapshot`. No need to know about °F or inHg. The poller and everything downstream just works.

## Tests
195 pass (including SI regression tests verifying identical API output)

## Test plan
- [x] All 195 backend tests pass
- [x] CI passes
- [x] Manual validation: dashboard shows correct display values

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## AI Disclosure
AI-assisted (Claude Code). All code reviewed and tested by the author.