### PR TITLE
Stabilize E2E tests for CI headless Chrome

### DIFF
--- a/tests/e2e/backup.spec.ts
+++ b/tests/e2e/backup.spec.ts
@@ -3,11 +3,11 @@ import { API_BASE } from './helpers/values';
 
 test.describe('Backup operations', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/settings');
-    await page.waitForSelector('h2:has-text("Settings")', { timeout: 15_000 });
-    // Navigate to Backup tab
+    await page.goto('/settings', { waitUntil: 'networkidle' });
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
     await page.getByRole('button', { name: 'Backup' }).click();
-    await page.waitForTimeout(500);
+    // Wait for tab content to render
+    await expect(page.getByRole('button', { name: /backup now/i })).toBeVisible();
   });
 
   // Clean up any backups created during tests
@@ -26,42 +26,33 @@ test.describe('Backup operations', () => {
   });
 
   test('create backup and verify it appears in list', async ({ page }) => {
-    // Click the Backup Now button
     const backupBtn = page.getByRole('button', { name: /backup now/i });
-    await expect(backupBtn).toBeVisible();
     await backupBtn.click();
-
-    // Wait for the backup to complete and appear in the list
-    await expect(page.getByText('kanfei-backup-').first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText('kanfei-backup-').first()).toBeVisible();
   });
 
   test('backup list shows download button', async ({ page }) => {
-    // Create a backup first via API to ensure there's one to download
+    // Create a backup first via API
     await page.request.post(`${API_BASE}/api/backup`);
-    await page.reload();
-    await page.waitForSelector('h2:has-text("Settings")', { timeout: 15_000 });
+    await page.reload({ waitUntil: 'networkidle' });
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
     await page.getByRole('button', { name: 'Backup' }).click();
-    await page.waitForTimeout(1000);
 
-    // Should have a download action
     const downloadBtn = page.getByRole('link', { name: /download/i }).or(
       page.getByRole('button', { name: /download/i })
     );
-    await expect(downloadBtn.first()).toBeVisible({ timeout: 10_000 });
+    await expect(downloadBtn.first()).toBeVisible();
   });
 
   test('delete backup removes it from list', async ({ page }) => {
     // Create a backup via API
     await page.request.post(`${API_BASE}/api/backup`);
-    await page.reload();
-    await page.waitForSelector('h2:has-text("Settings")', { timeout: 15_000 });
+    await page.reload({ waitUntil: 'networkidle' });
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
     await page.getByRole('button', { name: 'Backup' }).click();
-    await page.waitForTimeout(1000);
 
-    // Verify backup exists
-    await expect(page.getByText('kanfei-backup-').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('kanfei-backup-').first()).toBeVisible();
 
-    // Click delete button
     const deleteBtn = page.getByRole('button', { name: /delete/i }).first();
     await expect(deleteBtn).toBeVisible();
     await deleteBtn.click();

--- a/tests/e2e/build-test-db.py
+++ b/tests/e2e/build-test-db.py
@@ -116,7 +116,7 @@ def build_readings(now: datetime) -> list[dict]:
 
         if i == TOTAL_ROWS:
             # Anchor row — use exact values
-            row = dict(ANCHOR, timestamp=ts.isoformat())
+            row = dict(ANCHOR, timestamp=ts.strftime("%Y-%m-%d %H:%M:%S.%f"))
             rows.append(row)
             continue
 
@@ -143,7 +143,7 @@ def build_readings(now: datetime) -> list[dict]:
         feels_like = heat_index if outside_temp > 200 else wind_chill  # warm → HI
 
         row = {
-            "timestamp": ts.isoformat(),
+            "timestamp": ts.strftime("%Y-%m-%d %H:%M:%S.%f"),
             "station_type": 2,
             "inside_temp": inside_temp,
             "outside_temp": outside_temp,

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -3,12 +3,12 @@ import { ANCHOR, DAILY_EXTREMES } from './helpers/values';
 
 test.describe('Dashboard', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/', { waitUntil: 'networkidle' });
     // Wait for the REST /api/current fetch to populate the dashboard
     await page.waitForFunction(() => {
       const el = document.querySelector('.dashboard-grid');
       return el && el.children.length > 0;
-    }, { timeout: 15_000 });
+    });
   });
 
   test('page loads with dashboard grid', async ({ page }) => {
@@ -16,7 +16,6 @@ test.describe('Dashboard', () => {
   });
 
   test('outside temperature shows 75.2', async ({ page }) => {
-    // TemperatureGauge renders "75.2°F" in the digital readout
     const grid = page.locator('.dashboard-grid');
     await expect(grid.getByText(`${ANCHOR.outsideTemp}°F`).first()).toBeVisible();
   });
@@ -39,9 +38,7 @@ test.describe('Dashboard', () => {
 
   test('wind compass shows 8 mph SW', async ({ page }) => {
     const grid = page.locator('.dashboard-grid');
-    // Speed value (rendered as integer)
     await expect(grid.getByText(ANCHOR.windSpeed, { exact: true }).first()).toBeVisible();
-    // Cardinal + direction in bottom readout
     await expect(grid.getByText(`${ANCHOR.windCardinal} ${ANCHOR.windDirection}°`).first()).toBeVisible();
   });
 
@@ -57,28 +54,18 @@ test.describe('Dashboard', () => {
 
   test('rain gauge shows correct values', async ({ page }) => {
     const grid = page.locator('.dashboard-grid');
-
-    // Rain rate display
     await expect(grid.getByText(ANCHOR.rainRate).first()).toBeVisible();
-    // Rain totals — in full mode these are in separate "Today", "Yesterday", "Year" sections;
-    // in compact mode they're combined as "Day X / Yest Y / Yr Z"
     await expect(grid.getByText(ANCHOR.rainYearly).first()).toBeVisible();
     await expect(grid.getByText(ANCHOR.rainYesterday).first()).toBeVisible();
   });
 
   test('daily extremes show high and low on outside temp', async ({ page }) => {
     const grid = page.locator('.dashboard-grid');
-    // TemperatureGauge shows high/low as either SVG whisker labels "H 81°" / "L 68°"
-    // or compact card "H 81° / L 68°"
     await expect(grid.getByText(new RegExp(`H ${DAILY_EXTREMES.outsideTempHigh}°`)).first()).toBeVisible();
     await expect(grid.getByText(new RegExp(`L ${DAILY_EXTREMES.outsideTempLow}°`)).first()).toBeVisible();
   });
 
   test('solar-UV gauge does not render when data is null', async ({ page }) => {
-    // TileRenderer returns null for solar-uv when both values are null.
-    // The FlipTile wrapper may still exist with a hidden back face heading,
-    // but the SolarUVGauge component itself should not render.
-    // The gauge shows "W/m²" as a unit label — verify it's absent.
     const grid = page.locator('.dashboard-grid');
     await expect(grid.locator('text=W/m²')).toHaveCount(0);
   });

--- a/tests/e2e/derived.spec.ts
+++ b/tests/e2e/derived.spec.ts
@@ -3,20 +3,16 @@ import { ANCHOR } from './helpers/values';
 
 test.describe('Derived Conditions', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/');
-    // Wait for derived conditions panel to render with data
-    await page.waitForSelector('text=Derived Conditions', { timeout: 15_000 });
+    await page.goto('/', { waitUntil: 'networkidle' });
+    await expect(page.getByText('Derived Conditions')).toBeVisible();
   });
 
   test('panel header shows "Derived Conditions"', async ({ page }) => {
     await expect(page.getByText('Derived Conditions')).toBeVisible();
   });
 
-  // Helper: find a derived condition value by its label
-  // The panel has pairs of label + value divs
   async function assertDerived(page: import('@playwright/test').Page, label: string, expected: string) {
     await expect(page.getByText(label)).toBeVisible();
-    // The value div is a sibling of the label div inside the same container
     const container = page.locator(`text=${label}`).locator('..').locator(`text=${expected}`);
     await expect(container).toBeVisible();
   }

--- a/tests/e2e/history.spec.ts
+++ b/tests/e2e/history.spec.ts
@@ -2,8 +2,8 @@ import { test, expect } from '@playwright/test';
 
 test.describe('History page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/history');
-    await page.waitForSelector('h2:has-text("History")', { timeout: 15_000 });
+    await page.goto('/history', { waitUntil: 'networkidle' });
+    await expect(page.getByRole('heading', { name: 'History' })).toBeVisible();
   });
 
   test('page loads with sensor dropdown', async ({ page }) => {
@@ -19,22 +19,17 @@ test.describe('History page', () => {
   });
 
   test('chart renders with data', async ({ page }) => {
-    // Select a sensor that has data in our test DB
     const sensorSelect = page.locator('main select').first();
     await sensorSelect.selectOption({ label: 'Outdoor Temperature' });
-    // Use 24 Hours range to ensure we get data from today
     await page.getByRole('button', { name: '24 Hours' }).click();
-    // Wait for Highcharts to render
-    await page.waitForSelector('.highcharts-container', { timeout: 15_000 });
-    const chart = page.locator('.highcharts-container');
-    await expect(chart.first()).toBeVisible();
+    await expect(page.locator('.highcharts-container').first()).toBeVisible();
   });
 
   test('chart SVG has rendered paths', async ({ page }) => {
     const sensorSelect = page.locator('main select').first();
     await sensorSelect.selectOption({ label: 'Outdoor Temperature' });
     await page.getByRole('button', { name: '24 Hours' }).click();
-    await page.waitForSelector('.highcharts-container svg', { timeout: 15_000 });
+    await page.waitForSelector('.highcharts-container svg');
     const paths = page.locator('.highcharts-container svg path');
     const count = await paths.count();
     expect(count).toBeGreaterThan(0);
@@ -42,14 +37,11 @@ test.describe('History page', () => {
 
   test('switching sensor re-fetches data', async ({ page }) => {
     const sensorSelect = page.locator('main select').first();
-    // Select outdoor temp with 24h range to start
     await sensorSelect.selectOption({ label: 'Outdoor Temperature' });
     await page.getByRole('button', { name: '24 Hours' }).click();
-    await page.waitForTimeout(1500);
+    await page.waitForLoadState('networkidle');
 
-    // Switch to Indoor Temperature (also has data in test DB)
     await sensorSelect.selectOption({ label: 'Indoor Temperature' });
-    // Verify the dropdown value changed (key is temperature_inside)
     await expect(sensorSelect).toHaveValue('temperature_inside');
   });
 

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 const PORT = 8765;
 const BASE_URL = `http://localhost:${PORT}`;
+const IS_CI = !!process.env.CI;
 
 // Resolve paths relative to project root
 const projectRoot = path.resolve(__dirname, '../..');
@@ -12,16 +13,23 @@ export default defineConfig({
   testDir: '.',
   testMatch: '*.spec.ts',
   fullyParallel: false,
-  forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 1 : 0,
+  forbidOnly: IS_CI,
+  retries: IS_CI ? 1 : 0,
   workers: 1,
-  reporter: process.env.CI ? 'github' : 'html',
-  timeout: 30_000,
+  reporter: IS_CI ? 'github' : 'html',
+  timeout: IS_CI ? 60_000 : 30_000,
+
+  expect: {
+    // CI runners (headless Chrome, no GPU) need more time for React hydration
+    timeout: IS_CI ? 15_000 : 5_000,
+  },
 
   use: {
     baseURL: BASE_URL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
+    // Wait for all API fetches to complete before considering the page loaded
+    navigationTimeout: IS_CI ? 30_000 : 15_000,
   },
 
   globalSetup: './global-setup.ts',
@@ -34,8 +42,8 @@ export default defineConfig({
     ].join(' '),
     cwd: path.join(projectRoot, 'backend'),
     url: `${BASE_URL}/api/setup/status`,
-    reuseExistingServer: !process.env.CI,
-    timeout: 30_000,
+    reuseExistingServer: !IS_CI,
+    timeout: IS_CI ? 60_000 : 30_000,
     env: {
       ...process.env,
       KANFEI_DB_PATH: path.resolve(__dirname, 'fixtures', 'test.db'),

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -3,9 +3,8 @@ import { DRIVER_COUNT } from './helpers/values';
 
 test.describe('Settings page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/settings');
-    // Wait for the Settings page to fully render
-    await page.waitForSelector('h2:has-text("Settings")', { timeout: 15_000 });
+    await page.goto('/settings', { waitUntil: 'networkidle' });
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
   });
 
   /** The driver type dropdown is in the Station tab under "Driver Type" label. */
@@ -21,17 +20,12 @@ test.describe('Settings page', () => {
   test('driver dropdown has 7 options with legacy selected', async ({ page }) => {
     const select = driverSelect(page);
     await expect(select).toBeVisible();
-
-    // Should have 7 driver options
     const options = select.locator('option');
     await expect(options).toHaveCount(DRIVER_COUNT);
-
-    // Legacy should be selected (it's the configured driver)
     await expect(select).toHaveValue('legacy');
   });
 
   test('serial config visible for legacy driver', async ({ page }) => {
-    // With legacy driver, serial port and baud rate should be in the DOM
     const main = page.locator('main');
     await expect(main.getByText('Serial Port').first()).toBeVisible();
     await expect(main.getByText('Baud Rate').first()).toBeVisible();
@@ -39,10 +33,7 @@ test.describe('Settings page', () => {
 
   test('switching to ecowitt shows Gateway IP field', async ({ page }) => {
     await driverSelect(page).selectOption('ecowitt');
-
-    // Gateway IP should appear
     await expect(page.getByText('Gateway IP', { exact: false })).toBeVisible();
-    // Serial fields should be hidden
     await expect(page.locator('main').getByText('Serial Port')).toHaveCount(0);
   });
 
@@ -58,15 +49,12 @@ test.describe('Settings page', () => {
 
   test('switching to weatherlink_ip shows Device IP and TCP Port', async ({ page }) => {
     await driverSelect(page).selectOption('weatherlink_ip');
-    await page.waitForTimeout(300);
     await expect(page.getByText('Device IP Address')).toBeVisible();
     await expect(page.getByText('TCP Port')).toBeVisible();
   });
 
   test('WeatherLink section hidden for ecowitt', async ({ page }) => {
-    // Switch to ecowitt — WeatherLink archive period should disappear
     await driverSelect(page).selectOption('ecowitt');
-    await page.waitForTimeout(300);
     await expect(page.getByText('Archive Period', { exact: false })).toHaveCount(0);
   });
 

--- a/tests/e2e/wizard.spec.ts
+++ b/tests/e2e/wizard.spec.ts
@@ -3,13 +3,12 @@ import { API_BASE, DRIVER_COUNT } from './helpers/values';
 
 /** Helper: set setup_complete and ensure the page sees the change. */
 async function enterWizard(request: import('@playwright/test').APIRequestContext, page: import('@playwright/test').Page) {
-  // Set config
   await request.put(`${API_BASE}/api/config`, {
     data: [{ key: 'setup_complete', value: 'false' }],
   });
 
-  // Navigate and intercept the setup status API to guarantee the wizard appears.
-  // This avoids any race between the config write and the frontend's fetch.
+  // Intercept the setup status API to guarantee the wizard appears,
+  // avoiding any race between the config write and the frontend's fetch.
   await page.route('**/api/setup/status', async (route) => {
     await route.fulfill({
       status: 200,
@@ -19,9 +18,18 @@ async function enterWizard(request: import('@playwright/test').APIRequestContext
   });
 
   await page.goto('/');
-  await page.waitForSelector('text=Weather Station Setup', { timeout: 15_000 });
-  // Clear the route intercept for subsequent requests
+  await expect(page.getByText('Weather Station Setup')).toBeVisible();
   await page.unroute('**/api/setup/status');
+}
+
+/** Wait for the driver catalog API to populate the dropdown. */
+async function waitForDrivers(page: import('@playwright/test').Page) {
+  const driverSelect = page.locator('select').first();
+  await expect(driverSelect).toBeVisible();
+  await page.waitForFunction(
+    () => document.querySelector('select')!.options.length >= 7,
+  );
+  return driverSelect;
 }
 
 async function restoreSetup(request: import('@playwright/test').APIRequestContext) {
@@ -43,32 +51,20 @@ test.describe('Setup Wizard', () => {
 
   test('driver dropdown in step 1 has 7 options', async ({ request, page }) => {
     await enterWizard(request, page);
-    const driverSelect = page.locator('select').first();
-    await page.waitForFunction(
-      () => document.querySelector('select')!.options.length >= 7,
-      { timeout: 15_000 },
-    );
+    const driverSelect = await waitForDrivers(page);
     await expect(driverSelect.locator('option')).toHaveCount(DRIVER_COUNT);
   });
 
   test('selecting ecowitt shows Gateway IP field', async ({ request, page }) => {
     await enterWizard(request, page);
-    const driverSelect = page.locator('select').first();
-    await page.waitForFunction(
-      () => document.querySelector('select')!.options.length >= 7,
-      { timeout: 15_000 },
-    );
+    const driverSelect = await waitForDrivers(page);
     await driverSelect.selectOption('ecowitt');
     await expect(page.getByText('Gateway IP Address')).toBeVisible();
   });
 
   test('can navigate through all 3 steps', async ({ request, page }) => {
     await enterWizard(request, page);
-    const driverSelect = page.locator('select').first();
-    await page.waitForFunction(
-      () => document.querySelector('select')!.options.length >= 7,
-      { timeout: 15_000 },
-    );
+    const driverSelect = await waitForDrivers(page);
     await driverSelect.selectOption('ecowitt');
     await page.locator('input[type="text"]').first().fill('192.168.1.100');
     await page.getByRole('button', { name: 'Next' }).click();
@@ -82,11 +78,7 @@ test.describe('Setup Wizard', () => {
 
   test('Back button navigates to previous steps', async ({ request, page }) => {
     await enterWizard(request, page);
-    const driverSelect = page.locator('select').first();
-    await page.waitForFunction(
-      () => document.querySelector('select')!.options.length >= 7,
-      { timeout: 15_000 },
-    );
+    const driverSelect = await waitForDrivers(page);
     await driverSelect.selectOption('tempest');
     await page.getByRole('button', { name: 'Next' }).click();
     await expect(page.getByText('Step 2 of 3')).toBeVisible();
@@ -105,11 +97,7 @@ test.describe('Setup Wizard', () => {
 
   test('Finish Setup completes wizard and shows dashboard', async ({ request, page }) => {
     await enterWizard(request, page);
-    const driverSelect = page.locator('select').first();
-    await page.waitForFunction(
-      () => document.querySelector('select')!.options.length >= 7,
-      { timeout: 15_000 },
-    );
+    const driverSelect = await waitForDrivers(page);
     await driverSelect.selectOption('ecowitt');
     await page.locator('input[type="text"]').first().fill('192.168.1.100');
     await page.getByRole('button', { name: 'Next' }).click();
@@ -119,7 +107,7 @@ test.describe('Setup Wizard', () => {
     await page.getByRole('button', { name: 'Next' }).click();
 
     await page.getByRole('button', { name: /finish/i }).click();
-    await expect(page.getByText('Weather Station Setup')).toBeHidden({ timeout: 10_000 });
-    await expect(page.locator('.dashboard-grid')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Weather Station Setup')).toBeHidden();
+    await expect(page.locator('.dashboard-grid')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- Fix timestamp format bug in `build-test-db.py` that caused history API to return zero points (SQLAlchemy DateTime uses space separator, fixture was writing ISO `T` separator)
- Add CI-aware timeouts: `expect` 15s, navigation 30s, webServer 60s, test 60s
- Use `networkidle` wait strategy on all `page.goto()` calls so React hydration + API fetches complete before assertions
- Replace brittle `waitForTimeout` calls with proper element waits
- Extract `waitForDrivers` helper in wizard spec, use `getByRole` heading selectors

## Test plan

- [x] All 42 tests pass locally across multiple consecutive runs
- [x] Timestamp fix verified: history API returns 120 points (was 0)
- [ ] CI: needs verification on GitHub Actions ubuntu-latest (3 consecutive green runs)

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)