### PR TITLE
Add service management UI and improve reconnect UX

### DIFF
--- a/backend/app/api/setup.py
+++ b/backend/app/api/setup.py
@@ -172,7 +172,7 @@ async def complete_setup(config: SetupConfig, db: Session = Depends(get_db)):
             "cmd": "connect",
             "port": config.serial_port,
             "baud": config.baud_rate,
-        })
+        }, timeout=60.0)
         reconnect = result.get("data", {}) if result.get("ok") else {
             "success": False, "error": result.get("error", "Unknown error"),
         }
@@ -187,7 +187,7 @@ async def reconnect_endpoint():
     """Reconnect using current DB config."""
     try:
         client = get_ipc_client()
-        result = await client.send_command({"cmd": "reconnect"})
+        result = await client.send_command({"cmd": "reconnect"}, timeout=60.0)
         if result.get("ok"):
             return result["data"]
         return {"success": False, "error": result.get("error", "Unknown error")}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1556,6 +1556,42 @@ function SystemTab({ isMobile }: { isMobile: boolean }) {
           </div>
         )}
       </div>
+
+      {/* Service restart instructions */}
+      <div style={cardStyle}>
+        <h3 style={{
+          margin: "0 0 12px 0",
+          fontSize: "16px",
+          fontFamily: "var(--font-heading)",
+          color: "var(--color-text)",
+        }}>
+          Service Management
+        </h3>
+        <p style={{ fontSize: "13px", fontFamily: "var(--font-body)", color: "var(--color-text-secondary)", marginTop: 0, lineHeight: 1.5 }}>
+          Most settings take effect immediately or on the next cycle. To apply driver or connection changes, use <strong>Save &amp; Reconnect</strong> on the Station tab.
+        </p>
+        <p style={{ fontSize: "13px", fontFamily: "var(--font-body)", color: "var(--color-text-secondary)", marginTop: "8px", lineHeight: 1.5 }}>
+          If a full service restart is needed:
+        </p>
+        <div style={{
+          background: "var(--color-bg-secondary)",
+          borderRadius: "6px",
+          padding: "12px",
+          fontFamily: "'JetBrains Mono', monospace",
+          fontSize: "12px",
+          color: "var(--color-text)",
+          marginTop: "8px",
+          lineHeight: 1.6,
+        }}>
+          <div style={{ marginBottom: "8px", color: "var(--color-text-muted)", fontSize: "11px" }}>Windows (services):</div>
+          <div>net stop KanfeiWeb &amp;&amp; net stop KanfeiLogger</div>
+          <div>net start KanfeiLogger &amp;&amp; net start KanfeiWeb</div>
+          <div style={{ marginTop: "12px", marginBottom: "8px", color: "var(--color-text-muted)", fontSize: "11px" }}>Linux (systemd):</div>
+          <div>sudo systemctl restart kanfei-logger kanfei-web</div>
+          <div style={{ marginTop: "12px", marginBottom: "8px", color: "var(--color-text-muted)", fontSize: "11px" }}>Manual (dev mode):</div>
+          <div>Ctrl+C both terminals, then restart</div>
+        </div>
+      </div>
     </>
   );
 }
@@ -2215,7 +2251,7 @@ export default function Settings() {
               <option value="ambient">Ambient Weather (HTTP push)</option>
             </select>
             <span style={{ fontSize: "11px", color: "var(--color-text-muted)", display: "block", marginTop: "4px", fontFamily: "var(--font-body)" }}>
-              Changing driver type requires a restart of both the web app and logger daemon.
+              Click <strong>Save &amp; Reconnect</strong> after changing to apply the new driver.
             </span>
           </div>
           <div style={fieldGroup}>


### PR DESCRIPTION
## Summary

Ref #46. Improves the restart/reconnect experience for driver and connection changes.

## Changes

**Station tab:**
- Driver type hint now says "Click **Save & Reconnect** after changing to apply the new driver" instead of "requires a restart of both services"
- The existing Save & Reconnect button already handles driver changes via IPC reconnect — just needed clearer messaging

**System tab:**
- New **Service Management** card with:
  - Explanation of when restart is needed (most settings take effect immediately)
  - Platform-specific restart commands: Windows services, Linux systemd, dev mode
  - Monospace code blocks for copy-paste

## Why this is sufficient

- The IPC reconnect command already tears down and recreates the driver, including driver type changes
- The nowcast supervisor hot-reloads config every 30 seconds
- The backup scheduler hot-reloads config every cycle
- The only scenario requiring a full service restart is changing the IPC port or web bind address (extremely rare)

## Test plan
- [x] TypeScript compiles
- [x] Manual: verify hint text on Station tab
- [x] Manual: verify Service Management card on System tab

Ref #46

## AI Disclosure
AI-assisted (Claude Code).