### PR TITLE
Discord bot with slash commands and notifications

### DIFF
--- a/backend/app/api/config.py
+++ b/backend/app/api/config.py
@@ -94,6 +94,14 @@ _DEFAULTS: dict[str, object] = {
     "bot_telegram_commands": "current,status,help",
     "bot_telegram_notifications": "nowcast,alerts",
     "bot_telegram_last_error": "",
+    # Discord bot
+    "bot_discord_enabled": False,
+    "bot_discord_token": "",
+    "bot_discord_guild_id": "",       # target server ID
+    "bot_discord_channel_id": "",     # notification channel(s), comma-separated
+    "bot_discord_commands": "current,status,help",
+    "bot_discord_notifications": "nowcast,alerts",
+    "bot_discord_last_error": "",
     # Backup
     "backup_enabled": False,
     "backup_interval_hours": 24,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -232,8 +232,16 @@ async def lifespan(app: FastAPI):
         telegram_bot_supervisor(settings.db_path, settings.ipc_port, nc_events)
     )
 
+    # Start Discord bot supervisor — same pattern as Telegram.
+    from .services.discord_bot import discord_bot_supervisor
+    discord_task = asyncio.create_task(
+        discord_bot_supervisor(settings.db_path, settings.ipc_port, nc_events)
+    )
+
     yield
 
+    if discord_task is not None:
+        discord_task.cancel()
     if telegram_task is not None:
         telegram_task.cancel()
     if backup_task is not None:

--- a/backend/app/services/discord_bot.py
+++ b/backend/app/services/discord_bot.py
@@ -1,0 +1,431 @@
+"""Discord bot integration — gateway WebSocket bot for weather queries
+and outbound notifications for nowcast and alert events.
+"""
+
+import asyncio
+import logging
+import sqlite3
+from datetime import datetime, timezone
+
+from .bot_formatting import (
+    format_current_conditions,
+    format_alert_triggered,
+    format_alert_cleared,
+    format_nowcast_update,
+    format_help,
+    format_status,
+    get_current_conditions,
+)
+from .bot_ratelimit import RateLimiter
+
+logger = logging.getLogger(__name__)
+
+# How often the supervisor checks config for enable/disable changes (seconds).
+_SUPERVISOR_POLL = 30
+
+# Discord message length limit.
+_MAX_MESSAGE_LENGTH = 2000
+
+
+def _read_discord_config(db_path: str) -> dict:
+    """Read current Discord bot config from station_config (best-effort)."""
+    defaults = {
+        "bot_discord_enabled": False,
+        "bot_discord_token": "",
+        "bot_discord_guild_id": "",
+        "bot_discord_channel_id": "",
+        "bot_discord_commands": "current,status,help",
+        "bot_discord_notifications": "nowcast,alerts",
+    }
+    try:
+        conn = sqlite3.connect(db_path)
+        for key in defaults:
+            cur = conn.execute(
+                "SELECT value FROM station_config WHERE key = ?", (key,)
+            )
+            row = cur.fetchone()
+            if row is not None:
+                val = row[0]
+                if val.lower() in ("true", "false"):
+                    defaults[key] = val.lower() == "true"
+                else:
+                    defaults[key] = val
+        conn.close()
+    except Exception:
+        pass
+    return defaults
+
+
+def _update_discord_status(db_path: str, error: str = "") -> None:
+    """Write bot status to station_config (best-effort)."""
+    try:
+        conn = sqlite3.connect(db_path)
+        now = datetime.now(timezone.utc).isoformat()
+        conn.execute(
+            "INSERT OR REPLACE INTO station_config (key, value, updated_at) "
+            "VALUES (?, ?, ?)",
+            ("bot_discord_last_error", error, now),
+        )
+        conn.commit()
+        conn.close()
+    except Exception:
+        pass
+
+
+class DiscordBot:
+    """Discord bot using gateway WebSocket connection.
+
+    Uses discord.py slash commands for inbound queries and channel
+    messages for outbound notifications.
+    """
+
+    def __init__(self, token: str, guild_id: str, channel_ids: set[str],
+                 db_path: str, enabled_commands: set[str],
+                 enabled_notifications: set[str] | None = None,
+                 dry_run: bool = False) -> None:
+        self._token = token
+        self._guild_id = guild_id
+        self._channel_ids = channel_ids
+        self._db_path = db_path
+        self._enabled_commands = enabled_commands
+        self._enabled_notifications = enabled_notifications or {"nowcast", "alerts"}
+        self._dry_run = dry_run
+        self._rate_limiter = RateLimiter()
+        self._notified_alerts: set[str] = set()
+        self._client = None
+        self._tree = None
+        self._running = False
+
+    async def start(self) -> None:
+        """Start the bot gateway connection."""
+        if self._dry_run:
+            logger.info("Discord bot started in dry-run mode")
+            self._running = True
+            return
+
+        try:
+            import discord
+            from discord import app_commands
+        except ImportError:
+            logger.error(
+                "discord.py is not installed. "
+                "Install it with: pip install 'discord.py>=2.0'"
+            )
+            return
+
+        intents = discord.Intents.default()
+        self._client = discord.Client(intents=intents)
+        self._tree = app_commands.CommandTree(self._client)
+
+        guild_obj = discord.Object(id=int(self._guild_id)) if self._guild_id else None
+
+        if "current" in self._enabled_commands:
+            @self._tree.command(
+                name="current",
+                description="Current weather conditions",
+                guild=guild_obj,
+            )
+            async def cmd_current(interaction: discord.Interaction):
+                await self._handle_current(interaction)
+
+        if "status" in self._enabled_commands:
+            @self._tree.command(
+                name="status",
+                description="Station connection status",
+                guild=guild_obj,
+            )
+            async def cmd_status(interaction: discord.Interaction):
+                await self._handle_status(interaction)
+
+        if "help" in self._enabled_commands:
+            @self._tree.command(
+                name="help",
+                description="List available commands",
+                guild=guild_obj,
+            )
+            async def cmd_help(interaction: discord.Interaction):
+                await self._handle_help(interaction)
+
+        @self._client.event
+        async def on_ready():
+            if guild_obj:
+                self._tree.copy_global_to(guild=guild_obj)
+                await self._tree.sync(guild=guild_obj)
+            else:
+                await self._tree.sync()
+            logger.info(
+                "Discord bot ready (user=%s, guild=%s)",
+                self._client.user, self._guild_id or "global",
+            )
+
+        self._running = True
+        logger.info(
+            "Discord bot starting (commands=%s, guild=%s)",
+            ",".join(sorted(self._enabled_commands)),
+            self._guild_id or "global",
+        )
+
+        try:
+            await self._client.start(self._token)
+        except asyncio.CancelledError:
+            pass
+        finally:
+            await self.stop()
+
+    async def stop(self) -> None:
+        """Stop the bot gracefully."""
+        self._running = False
+        if self._client is not None and not self._client.is_closed():
+            try:
+                await self._client.close()
+            except Exception:
+                logger.debug("Error during Discord bot shutdown", exc_info=True)
+        self._client = None
+        self._tree = None
+        logger.info("Discord bot stopped")
+
+    def _is_channel_allowed(self, channel_id: str) -> bool:
+        """Check if a channel ID is in the whitelist (empty = allow all)."""
+        if not self._channel_ids:
+            return True
+        return channel_id in self._channel_ids
+
+    async def _send_response(self, interaction, text: str) -> None:
+        """Send an interaction response."""
+        if self._dry_run:
+            logger.info("DRY-RUN response:\n%s", text)
+            return
+        try:
+            await interaction.response.send_message(
+                text[:_MAX_MESSAGE_LENGTH]
+            )
+        except Exception:
+            logger.warning("Failed to send Discord response", exc_info=True)
+
+    async def _send_to_channel(self, channel_id: str, text: str) -> None:
+        """Send a message to a channel by ID."""
+        if self._dry_run:
+            logger.info("DRY-RUN message to channel %s:\n%s", channel_id, text)
+            return
+        if self._client is None:
+            return
+        try:
+            channel = self._client.get_channel(int(channel_id))
+            if channel is None:
+                channel = await self._client.fetch_channel(int(channel_id))
+            await channel.send(text[:_MAX_MESSAGE_LENGTH])
+        except Exception:
+            logger.warning("Failed to send Discord message to channel %s",
+                           channel_id, exc_info=True)
+
+    async def _handle_current(self, interaction) -> None:
+        """Handle the /current slash command."""
+        channel_id = str(interaction.channel_id)
+
+        if not self._is_channel_allowed(channel_id):
+            return
+
+        if self._rate_limiter.is_limited(channel_id, "current"):
+            await self._send_response(interaction, "Please wait a moment before using this command again.")
+            return
+
+        reading = get_current_conditions(self._db_path)
+        if reading is None:
+            await self._send_response(interaction, "No weather data available.")
+            return
+
+        text = format_current_conditions(reading)
+        await self._send_response(interaction, text)
+
+    async def _handle_status(self, interaction) -> None:
+        """Handle the /status slash command."""
+        channel_id = str(interaction.channel_id)
+
+        if not self._is_channel_allowed(channel_id):
+            return
+
+        if self._rate_limiter.is_limited(channel_id, "status"):
+            await self._send_response(interaction, "Please wait a moment before using this command again.")
+            return
+
+        reading = get_current_conditions(self._db_path)
+        text = format_status(reading)
+        await self._send_response(interaction, text)
+
+    async def _handle_help(self, interaction) -> None:
+        """Handle the /help slash command."""
+        channel_id = str(interaction.channel_id)
+
+        if not self._is_channel_allowed(channel_id):
+            return
+
+        if self._rate_limiter.is_limited(channel_id, "help"):
+            return
+
+        await self._send_response(interaction, format_help())
+
+    async def send_notification(self, text: str) -> None:
+        """Send a notification to all configured channels."""
+        if not text or not self._channel_ids:
+            return
+        for channel_id in self._channel_ids:
+            await self._send_to_channel(channel_id, text)
+
+    async def handle_event(self, message: dict) -> None:
+        """Process an IPC or emitter event and send notifications if applicable."""
+        event_type = message.get("type", "")
+        data = message.get("data", {})
+
+        if event_type == "alert_triggered" and "alerts" in self._enabled_notifications:
+            alert_id = data.get("id", "")
+            if alert_id in self._notified_alerts:
+                return
+            self._notified_alerts.add(alert_id)
+            text = format_alert_triggered(data)
+            await self.send_notification(text)
+
+        elif event_type == "alert_cleared" and "alerts" in self._enabled_notifications:
+            alert_id = data.get("id", "")
+            self._notified_alerts.discard(alert_id)
+            text = format_alert_cleared(data)
+            await self.send_notification(text)
+
+        elif event_type == "nowcast_update" and "nowcast" in self._enabled_notifications:
+            text = format_nowcast_update(data)
+            if text:
+                await self.send_notification(text)
+
+
+async def _ipc_event_loop(bot: DiscordBot, ipc_port: int) -> None:
+    """Subscribe to IPC events and route alert notifications to the bot."""
+    from ..ipc.client import IPCClient
+
+    while True:
+        try:
+            client = IPCClient(ipc_port)
+            async for msg in client.subscribe():
+                event_type = msg.get("type", "")
+                if event_type in ("alert_triggered", "alert_cleared"):
+                    await bot.handle_event(msg)
+        except asyncio.CancelledError:
+            break
+        except (ConnectionRefusedError, OSError):
+            await asyncio.sleep(5.0)
+        except Exception:
+            logger.debug("Discord IPC event loop error", exc_info=True)
+            await asyncio.sleep(5.0)
+
+
+async def discord_bot_supervisor(db_path: str, ipc_port: int = 0,
+                                 nc_events=None) -> None:
+    """Background supervisor that manages the Discord bot lifecycle.
+
+    Polls config every _SUPERVISOR_POLL seconds and starts, stops, or
+    restarts the bot as needed.
+
+    Args:
+        db_path: Path to the SQLite database.
+        ipc_port: Logger daemon IPC port for alert subscriptions.
+        nc_events: KanfeiEventEmitter instance for nowcast event listener.
+    """
+    logger.info("Discord bot supervisor started (poll every %ds)", _SUPERVISOR_POLL)
+
+    active_bot: DiscordBot | None = None
+    active_task: asyncio.Task | None = None
+    active_ipc_task: asyncio.Task | None = None
+    active_token: str = ""
+    listener_registered = False
+
+    def _nowcast_listener(msg: dict):
+        """Async callback registered with KanfeiEventEmitter."""
+        if active_bot is not None:
+            return active_bot.handle_event(msg)
+
+    def _stop_current() -> None:
+        nonlocal active_bot, active_task, active_ipc_task, active_token
+        nonlocal listener_registered
+        if active_ipc_task is not None:
+            active_ipc_task.cancel()
+            active_ipc_task = None
+        if active_task is not None:
+            active_task.cancel()
+            active_task = None
+        if listener_registered and nc_events is not None:
+            nc_events.remove_listener(_nowcast_listener)
+            listener_registered = False
+        active_bot = None
+        active_token = ""
+
+    while True:
+        try:
+            cfg = _read_discord_config(db_path)
+            enabled = cfg["bot_discord_enabled"]
+            token = cfg["bot_discord_token"]
+            guild_id = cfg["bot_discord_guild_id"]
+            channel_id_str = cfg["bot_discord_channel_id"]
+            commands_str = cfg["bot_discord_commands"]
+            notifications_str = cfg["bot_discord_notifications"]
+
+            if not enabled or not token:
+                if active_bot is not None:
+                    _stop_current()
+                    logger.info("Discord bot disabled via config")
+                    _update_discord_status(db_path)
+                await asyncio.sleep(_SUPERVISOR_POLL)
+                continue
+
+            channel_ids = {c.strip() for c in channel_id_str.split(",") if c.strip()}
+            enabled_commands = {c.strip() for c in commands_str.split(",") if c.strip()}
+            enabled_notifications = {c.strip() for c in notifications_str.split(",") if c.strip()}
+
+            # Restart if token changed
+            if active_bot is not None and token != active_token:
+                logger.info("Discord bot token changed, restarting")
+                _stop_current()
+
+            # Start if not running
+            if active_bot is None:
+                bot = DiscordBot(
+                    token=token,
+                    guild_id=guild_id,
+                    channel_ids=channel_ids,
+                    db_path=db_path,
+                    enabled_commands=enabled_commands,
+                    enabled_notifications=enabled_notifications,
+                )
+                active_task = asyncio.create_task(bot.start())
+                active_bot = bot
+                active_token = token
+                _update_discord_status(db_path)
+                logger.info("Discord bot started")
+
+                # Start IPC event loop for alert notifications
+                if ipc_port:
+                    active_ipc_task = asyncio.create_task(
+                        _ipc_event_loop(bot, ipc_port)
+                    )
+
+                # Register nowcast event listener
+                if nc_events is not None and not listener_registered:
+                    nc_events.add_listener(_nowcast_listener)
+                    listener_registered = True
+            else:
+                # Update mutable config without restart
+                active_bot._channel_ids = channel_ids
+                active_bot._enabled_commands = enabled_commands
+                active_bot._enabled_notifications = enabled_notifications
+
+            # Check if the bot task died
+            if active_task is not None and active_task.done():
+                exc = active_task.exception() if not active_task.cancelled() else None
+                if exc:
+                    logger.error("Discord bot crashed: %s — restarting", exc)
+                    _update_discord_status(db_path, error=str(exc))
+                else:
+                    logger.warning("Discord bot exited unexpectedly — restarting")
+                _stop_current()
+
+        except Exception:
+            logger.exception("Discord bot supervisor tick failed")
+
+        await asyncio.sleep(_SUPERVISOR_POLL)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "numpy>=1.24",             # Radar processing, threat tracking
     "matplotlib>=3.7",         # Radar composite visualizations
     "python-telegram-bot>=22.0",  # Telegram bot integration (async, getUpdates polling)
+    "discord.py>=2.0",             # Discord bot integration (async, gateway WebSocket)
 ]
 
 [project.optional-dependencies]

--- a/tests/backend/test_discord_bot.py
+++ b/tests/backend/test_discord_bot.py
@@ -1,0 +1,413 @@
+"""Tests for Discord bot service."""
+
+import sqlite3
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.discord_bot import (
+    DiscordBot,
+    _read_discord_config,
+)
+from app.services.bot_formatting import (
+    format_current_conditions,
+    format_alert_triggered,
+    format_alert_cleared,
+    format_nowcast_update,
+    format_help,
+    get_current_conditions,
+)
+
+
+@pytest.fixture
+def fake_db(tmp_path):
+    """Create a minimal SQLite DB with station_config and sensor_readings."""
+    db_path = tmp_path / "kanfei.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE station_config "
+        "(key TEXT PRIMARY KEY, value TEXT, updated_at TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE sensor_readings ("
+        "  id INTEGER PRIMARY KEY,"
+        "  timestamp TEXT,"
+        "  station_type INTEGER,"
+        "  inside_temp INTEGER,"
+        "  outside_temp INTEGER,"
+        "  inside_humidity INTEGER,"
+        "  outside_humidity INTEGER,"
+        "  wind_speed INTEGER,"
+        "  wind_direction INTEGER,"
+        "  barometer INTEGER,"
+        "  rain_total INTEGER,"
+        "  rain_rate INTEGER,"
+        "  rain_yearly INTEGER,"
+        "  solar_radiation INTEGER,"
+        "  uv_index INTEGER,"
+        "  extra_json TEXT,"
+        "  heat_index INTEGER,"
+        "  dew_point INTEGER,"
+        "  wind_chill INTEGER,"
+        "  feels_like INTEGER,"
+        "  theta_e INTEGER,"
+        "  pressure_trend TEXT"
+        ")"
+    )
+    conn.commit()
+    conn.close()
+    return str(db_path)
+
+
+@pytest.fixture
+def fake_db_with_reading(fake_db):
+    """Fake DB with one sensor reading."""
+    conn = sqlite3.connect(fake_db)
+    conn.execute(
+        "INSERT INTO sensor_readings "
+        "(timestamp, station_type, outside_temp, outside_humidity, "
+        " wind_speed, wind_direction, barometer, rain_total, rain_rate, "
+        " dew_point, feels_like, uv_index, pressure_trend) "
+        "VALUES (?, 17, 222, 62, 45, 180, 10132, 0, 0, 150, 230, 50, 'Steady')",
+        (datetime.now(timezone.utc).isoformat(),),
+    )
+    conn.commit()
+    conn.close()
+    return fake_db
+
+
+class TestReadDiscordConfig:
+
+    def test_defaults_when_empty(self, fake_db):
+        cfg = _read_discord_config(fake_db)
+        assert cfg["bot_discord_enabled"] is False
+        assert cfg["bot_discord_token"] == ""
+        assert cfg["bot_discord_guild_id"] == ""
+        assert cfg["bot_discord_channel_id"] == ""
+        assert cfg["bot_discord_commands"] == "current,status,help"
+        assert cfg["bot_discord_notifications"] == "nowcast,alerts"
+
+    def test_reads_saved_values(self, fake_db):
+        conn = sqlite3.connect(fake_db)
+        conn.execute(
+            "INSERT INTO station_config VALUES ('bot_discord_enabled', 'true', '2026-01-01')"
+        )
+        conn.execute(
+            "INSERT INTO station_config VALUES ('bot_discord_token', 'abc.123.xyz', '2026-01-01')"
+        )
+        conn.execute(
+            "INSERT INTO station_config VALUES ('bot_discord_guild_id', '999888777', '2026-01-01')"
+        )
+        conn.commit()
+        conn.close()
+
+        cfg = _read_discord_config(fake_db)
+        assert cfg["bot_discord_enabled"] is True
+        assert cfg["bot_discord_token"] == "abc.123.xyz"
+        assert cfg["bot_discord_guild_id"] == "999888777"
+
+    def test_nonexistent_db(self):
+        cfg = _read_discord_config("/nonexistent/db.sqlite")
+        assert cfg["bot_discord_enabled"] is False
+
+
+class TestChannelWhitelist:
+
+    def test_allows_whitelisted_channel(self):
+        bot = DiscordBot(
+            token="test", guild_id="", channel_ids={"123", "456"},
+            db_path="", enabled_commands={"current"}, dry_run=True,
+        )
+        assert bot._is_channel_allowed("123") is True
+        assert bot._is_channel_allowed("456") is True
+
+    def test_rejects_non_whitelisted_channel(self):
+        bot = DiscordBot(
+            token="test", guild_id="", channel_ids={"123"},
+            db_path="", enabled_commands={"current"}, dry_run=True,
+        )
+        assert bot._is_channel_allowed("999") is False
+
+    def test_empty_whitelist_allows_all(self):
+        bot = DiscordBot(
+            token="test", guild_id="", channel_ids=set(),
+            db_path="", enabled_commands={"current"}, dry_run=True,
+        )
+        assert bot._is_channel_allowed("anything") is True
+
+
+class TestHandleCurrentCommand:
+
+    @pytest.mark.asyncio
+    async def test_sends_conditions(self, fake_db_with_reading):
+        bot = DiscordBot(
+            token="test", guild_id="", channel_ids=set(),
+            db_path=fake_db_with_reading,
+            enabled_commands={"current"}, dry_run=True,
+        )
+        bot._send_response = AsyncMock()
+
+        interaction = MagicMock()
+        interaction.channel_id = 123
+
+        await bot._handle_current(interaction)
+
+        bot._send_response.assert_called_once()
+        text = bot._send_response.call_args[0][1]
+        assert "72.0\u00b0F" in text
+
+    @pytest.mark.asyncio
+    async def test_no_data_message(self, fake_db):
+        bot = DiscordBot(
+            token="test", guild_id="", channel_ids=set(),
+            db_path=fake_db,
+            enabled_commands={"current"}, dry_run=True,
+        )
+        bot._send_response = AsyncMock()
+
+        interaction = MagicMock()
+        interaction.channel_id = 123
+
+        await bot._handle_current(interaction)
+
+        bot._send_response.assert_called_once()
+        text = bot._send_response.call_args[0][1]
+        assert "No weather data" in text
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_channel_ignored(self, fake_db_with_reading):
+        bot = DiscordBot(
+            token="test", guild_id="", channel_ids={"999"},
+            db_path=fake_db_with_reading,
+            enabled_commands={"current"}, dry_run=True,
+        )
+        bot._send_response = AsyncMock()
+
+        interaction = MagicMock()
+        interaction.channel_id = 123
+
+        await bot._handle_current(interaction)
+
+        bot._send_response.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rate_limited(self, fake_db_with_reading):
+        bot = DiscordBot(
+            token="test", guild_id="", channel_ids=set(),
+            db_path=fake_db_with_reading,
+            enabled_commands={"current"}, dry_run=True,
+        )
+        bot._send_response = AsyncMock()
+
+        interaction = MagicMock()
+        interaction.channel_id = 123
+
+        await bot._handle_current(interaction)
+        bot._send_response.reset_mock()
+
+        await bot._handle_current(interaction)
+        bot._send_response.assert_called_once()
+        assert "wait" in bot._send_response.call_args[0][1].lower()
+
+
+class TestHandleStatusCommand:
+
+    @pytest.mark.asyncio
+    async def test_sends_status(self, fake_db_with_reading):
+        bot = DiscordBot(
+            token="test", guild_id="", channel_ids=set(),
+            db_path=fake_db_with_reading,
+            enabled_commands={"status"}, dry_run=True,
+        )
+        bot._send_response = AsyncMock()
+
+        interaction = MagicMock()
+        interaction.channel_id = 123
+
+        await bot._handle_status(interaction)
+
+        bot._send_response.assert_called_once()
+        text = bot._send_response.call_args[0][1]
+        assert "Station Status" in text
+        assert "online" in text
+
+    @pytest.mark.asyncio
+    async def test_offline_when_no_data(self, fake_db):
+        bot = DiscordBot(
+            token="test", guild_id="", channel_ids=set(),
+            db_path=fake_db,
+            enabled_commands={"status"}, dry_run=True,
+        )
+        bot._send_response = AsyncMock()
+
+        interaction = MagicMock()
+        interaction.channel_id = 123
+
+        await bot._handle_status(interaction)
+
+        bot._send_response.assert_called_once()
+        text = bot._send_response.call_args[0][1]
+        assert "offline" in text
+
+
+class TestHandleHelpCommand:
+
+    @pytest.mark.asyncio
+    async def test_sends_help(self):
+        bot = DiscordBot(
+            token="test", guild_id="", channel_ids=set(),
+            db_path="", enabled_commands={"help"}, dry_run=True,
+        )
+        bot._send_response = AsyncMock()
+
+        interaction = MagicMock()
+        interaction.channel_id = 123
+
+        await bot._handle_help(interaction)
+
+        bot._send_response.assert_called_once()
+        text = bot._send_response.call_args[0][1]
+        assert "/current" in text
+        assert "/help" in text
+
+
+class TestHandleEvent:
+
+    @pytest.mark.asyncio
+    async def test_alert_triggered_sends_notification(self):
+        bot = DiscordBot(
+            token="test", guild_id="", channel_ids={"123"},
+            db_path="", enabled_commands=set(),
+            enabled_notifications={"alerts"}, dry_run=True,
+        )
+        bot.send_notification = AsyncMock()
+
+        await bot.handle_event({
+            "type": "alert_triggered",
+            "data": {
+                "id": "a1", "label": "Wind Alert",
+                "sensor": "wind_speed", "value": 35,
+                "threshold": 30, "operator": ">=",
+            },
+        })
+
+        bot.send_notification.assert_called_once()
+        assert "Wind Alert" in bot.send_notification.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_alert_triggered_dedup(self):
+        bot = DiscordBot(
+            token="test", guild_id="", channel_ids={"123"},
+            db_path="", enabled_commands=set(),
+            enabled_notifications={"alerts"}, dry_run=True,
+        )
+        bot.send_notification = AsyncMock()
+
+        msg = {
+            "type": "alert_triggered",
+            "data": {"id": "a1", "label": "Wind Alert",
+                     "sensor": "wind_speed", "value": 35,
+                     "threshold": 30, "operator": ">="},
+        }
+        await bot.handle_event(msg)
+        await bot.handle_event(msg)
+
+        assert bot.send_notification.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_alert_cleared_sends_notification(self):
+        bot = DiscordBot(
+            token="test", guild_id="", channel_ids={"123"},
+            db_path="", enabled_commands=set(),
+            enabled_notifications={"alerts"}, dry_run=True,
+        )
+        bot.send_notification = AsyncMock()
+
+        await bot.handle_event({
+            "type": "alert_triggered",
+            "data": {"id": "a1", "label": "Wind Alert",
+                     "sensor": "wind_speed", "value": 35,
+                     "threshold": 30, "operator": ">="},
+        })
+        bot.send_notification.reset_mock()
+
+        await bot.handle_event({
+            "type": "alert_cleared",
+            "data": {"id": "a1", "label": "Wind Alert"},
+        })
+
+        bot.send_notification.assert_called_once()
+        assert "cleared" in bot.send_notification.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_nowcast_update_sends_notification(self):
+        bot = DiscordBot(
+            token="test", guild_id="", channel_ids={"123"},
+            db_path="", enabled_commands=set(),
+            enabled_notifications={"nowcast"}, dry_run=True,
+        )
+        bot.send_notification = AsyncMock()
+
+        await bot.handle_event({
+            "type": "nowcast_update",
+            "data": {"summary": "Rain expected within 30 minutes."},
+        })
+
+        bot.send_notification.assert_called_once()
+        assert "Rain expected" in bot.send_notification.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_disabled_notifications_ignored(self):
+        bot = DiscordBot(
+            token="test", guild_id="", channel_ids={"123"},
+            db_path="", enabled_commands=set(),
+            enabled_notifications={"alerts"}, dry_run=True,
+        )
+        bot.send_notification = AsyncMock()
+
+        await bot.handle_event({
+            "type": "nowcast_update",
+            "data": {"summary": "Rain expected."},
+        })
+
+        bot.send_notification.assert_not_called()
+
+
+class TestSendNotification:
+
+    @pytest.mark.asyncio
+    async def test_sends_to_all_channels(self):
+        bot = DiscordBot(
+            token="test", guild_id="", channel_ids={"111", "222"},
+            db_path="", enabled_commands=set(), dry_run=True,
+        )
+        bot._send_to_channel = AsyncMock()
+
+        await bot.send_notification("Test message")
+
+        assert bot._send_to_channel.call_count == 2
+        sent_channels = {call[0][0] for call in bot._send_to_channel.call_args_list}
+        assert sent_channels == {"111", "222"}
+
+    @pytest.mark.asyncio
+    async def test_empty_text_skipped(self):
+        bot = DiscordBot(
+            token="test", guild_id="", channel_ids={"123"},
+            db_path="", enabled_commands=set(), dry_run=True,
+        )
+        bot._send_to_channel = AsyncMock()
+
+        await bot.send_notification("")
+        bot._send_to_channel.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_channels_skipped(self):
+        bot = DiscordBot(
+            token="test", guild_id="", channel_ids=set(),
+            db_path="", enabled_commands=set(), dry_run=True,
+        )
+        bot._send_to_channel = AsyncMock()
+
+        await bot.send_notification("Test")
+        bot._send_to_channel.assert_not_called()


### PR DESCRIPTION
## Summary

Discord bot integration covering Phases 1a + 1b of #71 (Ref #64). Uses discord.py gateway WebSocket (NAT/CGNAT compatible) with slash commands and outbound notifications. Reuses shared bot infrastructure from #73.

Phases 1a and 1b are combined since the shared `BotAdapter` protocol, formatters, and `RateLimiter` from #73 made notifications trivial to add alongside commands.

## Changes

- `backend/pyproject.toml` — added `discord.py>=2.0`
- `backend/app/api/config.py` — added `bot_discord_*` config keys
- `backend/app/main.py` — added `discord_bot_supervisor` to lifespan
- `backend/app/services/discord_bot.py` — new Discord bot service
- `tests/backend/test_discord_bot.py` — 21 new tests (277 total)

## Features

### Commands (Phase 1a)
- `/current` — formatted weather conditions (guild-scoped slash command)
- `/status` — station connection status and data age
- `/help` — list available commands
- Channel whitelist (empty = allow all)
- Per-command rate limiting via shared `RateLimiter`

### Notifications (Phase 1b)
- Alert threshold notifications with deduplication (first trigger only)
- Alert cleared notifications
- Nowcast update notifications
- Configurable via `bot_discord_notifications` config key
- IPC subscription for alerts, event emitter listener for nowcast

## Test plan

- [x] `cd backend && python3 -m pytest ../tests/backend/ -q` — 277 tests pass
- [x] `python3 -m py_compile backend/app/services/discord_bot.py`

### Bot connectivity
- [x] Bot disabled by default — no Discord connections in logs with no config set
- [x] Enable with a real bot token and guild ID — confirm "Discord bot ready" in logs
- [x] `/current` returns formatted weather in Discord
- [x] `/status` returns station info
- [x] `/help` lists available commands

### Channel whitelist
- [ ] Set `bot_discord_channel_id` — commands in non-whitelisted channels are ignored
- [ ] Empty channel ID allows all channels

### Notifications
- [ ] Alert threshold exceeded — notification sent to configured channel
- [ ] Repeated readings above threshold do NOT send duplicate notifications
- [ ] Alert cleared — "cleared" notification sent
- [ ] Nowcast update — summary notification sent
- [ ] `bot_discord_notifications` filtering works (alerts only, nowcast only, both, neither)

### Resilience
- [ ] Disable via config — "Discord bot disabled" in logs, bot stops
- [ ] Invalid token — error logged, written to `bot_discord_last_error`, app does not crash

## Testing

- [x] Backend tests pass — 277 passed, 0 failures
- [x] `py_compile` on all new/modified files
- [x] 21 new tests covering commands, whitelist, rate limiting, event handling, notifications

## AI Disclosure

AI-assisted (Claude Code). All code reviewed and verified against existing codebase patterns.

Ref #71