### PR TITLE
Move bot settings to dedicated Bots tab

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1608,7 +1608,7 @@ export default function Settings() {
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [reconnectMsg, setReconnectMsg] = useState<string | null>(null);
   const [ports, setPorts] = useState<string[]>([]);
-  const [activeTab, setActiveTab] = useState<"station" | "display" | "services" | "alerts" | "nowcast" | "spray" | "usage" | "database" | "backup" | "system">("station");
+  const [activeTab, setActiveTab] = useState<"station" | "display" | "services" | "bots" | "alerts" | "nowcast" | "spray" | "usage" | "database" | "backup" | "system">("station");
   const [telegramTesting, setTelegramTesting] = useState(false);
   const [telegramTestResult, setTelegramTestResult] = useState<string | null>(null);
   const [discordTesting, setDiscordTesting] = useState(false);
@@ -1999,6 +1999,7 @@ export default function Settings() {
           ["station", "Station"],
           ["display", "Display"],
           ["services", "Services"],
+          ["bots", "Bots"],
           ["alerts", "Alerts"],
           ...(flags.nowcastEnabled ? [["nowcast", "Nowcast"] as const] : []),
           ...(flags.sprayEnabled ? [["spray", "Spray"] as const] : []),
@@ -2964,6 +2965,9 @@ export default function Settings() {
         </div>
       </div>
 
+      </>)}
+
+      {activeTab === "bots" && (<>
       {/* Telegram Bot section */}
       <div style={{ ...cardStyle, padding: isMobile ? "12px" : "20px" }}>
         <h3 style={sectionTitle}>Telegram Bot</h3>

--- a/tests/e2e/discord.spec.ts
+++ b/tests/e2e/discord.spec.ts
@@ -8,8 +8,8 @@ test.describe('Discord Bot settings', () => {
     await page.goto('/settings');
     await configReady;
     await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
-    // Navigate to Services tab where Discord settings live
-    await page.getByRole('button', { name: 'Services' }).click();
+    // Navigate to Bots tab where Discord settings live
+    await page.getByRole('button', { name: 'Bots' }).click();
     await expect(page.getByRole('heading', { name: 'Discord Bot' })).toBeVisible();
   });
 

--- a/tests/e2e/telegram.spec.ts
+++ b/tests/e2e/telegram.spec.ts
@@ -8,8 +8,8 @@ test.describe('Telegram Bot settings', () => {
     await page.goto('/settings');
     await configReady;
     await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
-    // Navigate to Services tab where Telegram settings live
-    await page.getByRole('button', { name: 'Services' }).click();
+    // Navigate to Bots tab where Telegram settings live
+    await page.getByRole('button', { name: 'Bots' }).click();
     await expect(page.getByRole('heading', { name: 'Telegram Bot' })).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary

Extracts Telegram and Discord bot configuration cards from the Services tab into a new dedicated **Bots** tab in Settings. Keeps Services focused on data services (METAR, NWS, WU, CWOP).

Closes #81

## Changes

- `frontend/src/pages/Settings.tsx` — added "bots" to tab type union and tab bar, moved bot cards to new `activeTab === "bots"` block
- `tests/e2e/telegram.spec.ts` — navigate to Bots tab instead of Services
- `tests/e2e/discord.spec.ts` — navigate to Bots tab instead of Services

## Test plan

- [x] `cd frontend && npx tsc --noEmit` — zero errors
- [x] `cd frontend && npm run build` — builds successfully
- [x] New "Bots" tab visible in Settings tab bar
- [x] Telegram and Discord cards render correctly in Bots tab
- [x] Services tab no longer contains bot cards
- [x] All bot functionality unchanged (enable/disable, config fields, test message button)
- [x] Other Settings tabs unaffected

## E2E Results

| Metric | Value |
|--------|-------|
| Status | **PASS** |
| Passed | 56 |
| Failed | 0 |
| Total | 56 |
| Duration | 78s |
| Branch | `feature/e2e/bot-settings-tab` |
| Commit | `84db6ea` |

## Testing

- [x] Frontend compiles (`npx tsc --noEmit`)
- [x] Frontend builds
- [x] E2E tests pass — 56/56

## AI Disclosure

AI-assisted (Claude Code).

Closes #81