### PR TITLE
Add wind-field vorticity overlay to 3D pressure field

### DIFF
--- a/frontend/src/pages/PressureField.tsx
+++ b/frontend/src/pages/PressureField.tsx
@@ -531,7 +531,6 @@ function VorticityOverlay({ data, opacity }: { data: PressureGridData; opacity: 
 
     // --- Vorticity = ∂gradR/∂c - ∂gradC/∂r (curl of gradient) ---
     const vort: number[][] = [];
-    let maxAbs = 0;
     for (let r = 0; r < rows; r++) {
       vort[r] = [];
       for (let c = 0; c < cols; c++) {
@@ -542,11 +541,20 @@ function VorticityOverlay({ data, opacity }: { data: PressureGridData; opacity: 
           ? (gradC[r + 1][c] - gradC[r - 1][c]) / 2
           : r === 0 ? gradC[1][c] - gradC[0][c] : gradC[r][c] - gradC[r - 1][c];
         vort[r][c] = dGradR_dc - dGradC_dr;
-        const a = Math.abs(vort[r][c]);
-        if (a > maxAbs) maxAbs = a;
       }
     }
-    if (maxAbs < 1e-10) maxAbs = 1;
+
+    // Use p95 of |vorticity| for normalization so edge/station artifacts
+    // don't compress the entire color range into invisible near-zero.
+    const allAbs: number[] = [];
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        allAbs.push(Math.abs(vort[r][c]));
+      }
+    }
+    allAbs.sort((a, b) => a - b);
+    const p95 = allAbs[Math.floor(allAbs.length * 0.95)] || 1;
+    const normScale = Math.max(p95, 1e-10);
 
     // --- Build draped mesh with vertex colors ---
     // Near-zero vorticity fades toward a neutral grey so only significant
@@ -565,12 +573,15 @@ function VorticityOverlay({ data, opacity }: { data: PressureGridData; opacity: 
         pos.setY(idx, y);
 
         // Normalize vorticity to [0, 1] range centered at 0.5
-        const t = 0.5 + (vort[r][c] / maxAbs) * 0.5;
+        // Clamp so values beyond p95 saturate instead of overflowing
+        const raw = vort[r][c] / normScale;
+        const clamped = Math.max(-1, Math.min(1, raw));
+        const t = 0.5 + clamped * 0.5;
         const [cr, cg, cb] = vorticityColor(t);
 
         // Blend toward neutral grey where vorticity is weak
-        const intensity = Math.abs(vort[r][c]) / maxAbs;
-        const blend = Math.pow(intensity, 1.5); // power curve: only strong vorticity shows
+        const intensity = Math.min(Math.abs(raw), 1);
+        const blend = Math.pow(intensity, 0.8); // gentler curve with p95 normalization
         const neutral = 0.35; // dark neutral
         colors[idx * 3] = neutral + (cr - neutral) * blend;
         colors[idx * 3 + 1] = neutral + (cg - neutral) * blend;

--- a/frontend/src/pages/PressureField.tsx
+++ b/frontend/src/pages/PressureField.tsx
@@ -482,7 +482,7 @@ function GradientFlowLines({ data, coriolis }: { data: PressureGridData; corioli
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
-// Vorticity overlay — curl of the pressure gradient field
+// Vorticity overlay — curl of observed wind field (∂v/∂x - ∂u/∂y)
 // ---------------------------------------------------------------------------
 
 /**
@@ -490,7 +490,6 @@ function GradientFlowLines({ data, coriolis }: { data: PressureGridData; corioli
  * t ∈ [0, 1] where 0 = max anticyclonic, 0.5 = zero, 1 = max cyclonic.
  * Anticyclonic (t < 0.5): warm red/orange
  * Cyclonic    (t > 0.5): cool cyan/blue
- * Near-zero   (t ≈ 0.5): transparent (handled by alpha, not here)
  */
 function vorticityColor(t: number): [number, number, number] {
   const tc = Math.max(0, Math.min(1, t));
@@ -506,46 +505,79 @@ function vorticityColor(t: number): [number, number, number] {
 }
 
 function VorticityOverlay({ data, opacity }: { data: PressureGridData; opacity: number }) {
-  const { grid, rows, cols, pressure_min, pressure_max } = data;
+  const { grid, rows, cols, pressure_min, pressure_max, stations,
+          lat_min, lat_max, lon_min, lon_max } = data;
   const sceneWidth = 10;
   const sceneDepth = 10 * (rows / cols);
   const pRange = (pressure_max - pressure_min) || 1;
   const heightScale = 8;
 
   const geometry = useMemo(() => {
-    // --- Compute gradient field (central finite differences) ---
-    const gradC: number[][] = [];
-    const gradR: number[][] = [];
+    // --- IDW-interpolate u/v wind components onto the grid ---
+    // Filter to stations with both speed and direction
+    const windStations = stations.filter(
+      (s) => s.wind_mph != null && s.wind_dir != null && s.wind_mph >= 0
+    );
+    if (windStations.length < 3) return null;
+
+    // Decompose met-convention wind (dir = FROM, CW from N) to u/v
+    // u = east component, v = north component
+    const stationUV = windStations.map((s) => {
+      const dirRad = (s.wind_dir! * Math.PI) / 180;
+      // Wind FROM dir means the flow is opposite to the direction
+      return {
+        lat: s.lat, lon: s.lon,
+        u: -s.wind_mph! * Math.sin(dirRad),
+        v: -s.wind_mph! * Math.cos(dirRad),
+      };
+    });
+
+    // IDW interpolation of u and v onto the grid
+    const uGrid: number[][] = [];
+    const vGrid: number[][] = [];
     for (let r = 0; r < rows; r++) {
-      gradC[r] = [];
-      gradR[r] = [];
+      uGrid[r] = [];
+      vGrid[r] = [];
+      const lat = lat_min + (r / (rows - 1)) * (lat_max - lat_min);
       for (let c = 0; c < cols; c++) {
-        gradC[r][c] = c > 0 && c < cols - 1
-          ? (grid[r][c + 1] - grid[r][c - 1]) / 2
-          : c === 0 ? grid[r][1] - grid[r][0] : grid[r][c] - grid[r][c - 1];
-        gradR[r][c] = r > 0 && r < rows - 1
-          ? (grid[r + 1][c] - grid[r - 1][c]) / 2
-          : r === 0 ? grid[1][c] - grid[0][c] : grid[r][c] - grid[r - 1][c];
+        const lon = lon_min + (c / (cols - 1)) * (lon_max - lon_min);
+        let wSum = 0, uSum = 0, vSum = 0;
+        for (const s of stationUV) {
+          const dlat = s.lat - lat;
+          const dlon = s.lon - lon;
+          const d2 = dlat * dlat + dlon * dlon;
+          if (d2 < 1e-10) {
+            // Coincident with station — use its value directly
+            wSum = 1; uSum = s.u; vSum = s.v;
+            break;
+          }
+          const w = 1 / d2; // power=2
+          wSum += w;
+          uSum += w * s.u;
+          vSum += w * s.v;
+        }
+        uGrid[r][c] = wSum > 0 ? uSum / wSum : 0;
+        vGrid[r][c] = wSum > 0 ? vSum / wSum : 0;
       }
     }
 
-    // --- Vorticity = ∂gradR/∂c - ∂gradC/∂r (curl of gradient) ---
+    // --- Vorticity = ∂v/∂x - ∂u/∂y (curl of wind field) ---
+    // In grid space: ∂v/∂c - ∂u/∂r (c ~ x/lon, r ~ y/lat)
     const vort: number[][] = [];
     for (let r = 0; r < rows; r++) {
       vort[r] = [];
       for (let c = 0; c < cols; c++) {
-        const dGradR_dc = c > 0 && c < cols - 1
-          ? (gradR[r][c + 1] - gradR[r][c - 1]) / 2
-          : c === 0 ? gradR[r][1] - gradR[r][0] : gradR[r][c] - gradR[r][c - 1];
-        const dGradC_dr = r > 0 && r < rows - 1
-          ? (gradC[r + 1][c] - gradC[r - 1][c]) / 2
-          : r === 0 ? gradC[1][c] - gradC[0][c] : gradC[r][c] - gradC[r - 1][c];
-        vort[r][c] = dGradR_dc - dGradC_dr;
+        const dv_dc = c > 0 && c < cols - 1
+          ? (vGrid[r][c + 1] - vGrid[r][c - 1]) / 2
+          : c === 0 ? vGrid[r][1] - vGrid[r][0] : vGrid[r][c] - vGrid[r][c - 1];
+        const du_dr = r > 0 && r < rows - 1
+          ? (uGrid[r + 1][c] - uGrid[r - 1][c]) / 2
+          : r === 0 ? uGrid[1][c] - uGrid[0][c] : uGrid[r][c] - uGrid[r - 1][c];
+        vort[r][c] = dv_dc - du_dr;
       }
     }
 
-    // Use p95 of |vorticity| for normalization so edge/station artifacts
-    // don't compress the entire color range into invisible near-zero.
+    // p95 normalization so edge artifacts don't wash out the interior
     const allAbs: number[] = [];
     for (let r = 0; r < rows; r++) {
       for (let c = 0; c < cols; c++) {
@@ -557,8 +589,6 @@ function VorticityOverlay({ data, opacity }: { data: PressureGridData; opacity: 
     const normScale = Math.max(p95, 1e-10);
 
     // --- Build draped mesh with vertex colors ---
-    // Near-zero vorticity fades toward a neutral grey so only significant
-    // rotation is visually prominent.
     const geo = new THREE.PlaneGeometry(sceneWidth, sceneDepth, cols - 1, rows - 1);
     geo.rotateX(-Math.PI / 2);
 
@@ -572,8 +602,6 @@ function VorticityOverlay({ data, opacity }: { data: PressureGridData; opacity: 
         const y = ((p - pressure_min) / pRange) * heightScale + 0.05;
         pos.setY(idx, y);
 
-        // Normalize vorticity to [0, 1] range centered at 0.5
-        // Clamp so values beyond p95 saturate instead of overflowing
         const raw = vort[r][c] / normScale;
         const clamped = Math.max(-1, Math.min(1, raw));
         const t = 0.5 + clamped * 0.5;
@@ -581,8 +609,8 @@ function VorticityOverlay({ data, opacity }: { data: PressureGridData; opacity: 
 
         // Blend toward neutral grey where vorticity is weak
         const intensity = Math.min(Math.abs(raw), 1);
-        const blend = Math.pow(intensity, 0.8); // gentler curve with p95 normalization
-        const neutral = 0.35; // dark neutral
+        const blend = Math.pow(intensity, 0.8);
+        const neutral = 0.35;
         colors[idx * 3] = neutral + (cr - neutral) * blend;
         colors[idx * 3 + 1] = neutral + (cg - neutral) * blend;
         colors[idx * 3 + 2] = neutral + (cb - neutral) * blend;
@@ -592,7 +620,10 @@ function VorticityOverlay({ data, opacity }: { data: PressureGridData; opacity: 
     geo.setAttribute("color", new THREE.BufferAttribute(colors, 3));
 
     return geo;
-  }, [grid, rows, cols, pressure_min, pressure_max, pRange, heightScale]);
+  }, [grid, rows, cols, pressure_min, pressure_max, pRange, heightScale,
+      stations, lat_min, lat_max, lon_min, lon_max]);
+
+  if (!geometry) return null;
 
   return (
     <mesh geometry={geometry}>

--- a/frontend/src/pages/PressureField.tsx
+++ b/frontend/src/pages/PressureField.tsx
@@ -481,6 +481,121 @@ function GradientFlowLines({ data, coriolis }: { data: PressureGridData; corioli
 // Temperature overlay — IDW-interpolated station temps draped on the surface
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Vorticity overlay — curl of the pressure gradient field
+// ---------------------------------------------------------------------------
+
+/**
+ * Map signed vorticity to a diverging color ramp.
+ * t ∈ [0, 1] where 0 = max anticyclonic, 0.5 = zero, 1 = max cyclonic.
+ * Anticyclonic (t < 0.5): warm red/orange
+ * Cyclonic    (t > 0.5): cool cyan/blue
+ * Near-zero   (t ≈ 0.5): transparent (handled by alpha, not here)
+ */
+function vorticityColor(t: number): [number, number, number] {
+  const tc = Math.max(0, Math.min(1, t));
+  if (tc < 0.5) {
+    // Anticyclonic: red (0) → orange (0.25) → pale (0.5)
+    const s = tc / 0.5; // 0→1
+    return [1.0 - 0.3 * s, 0.25 + 0.55 * s, 0.15 + 0.65 * s];
+  } else {
+    // Cyclonic: pale (0.5) → cyan (0.75) → blue (1)
+    const s = (tc - 0.5) / 0.5; // 0→1
+    return [0.7 - 0.55 * s, 0.8 - 0.15 * s, 0.8 + 0.2 * s];
+  }
+}
+
+function VorticityOverlay({ data, opacity }: { data: PressureGridData; opacity: number }) {
+  const { grid, rows, cols, pressure_min, pressure_max } = data;
+  const sceneWidth = 10;
+  const sceneDepth = 10 * (rows / cols);
+  const pRange = (pressure_max - pressure_min) || 1;
+  const heightScale = 8;
+
+  const geometry = useMemo(() => {
+    // --- Compute gradient field (central finite differences) ---
+    const gradC: number[][] = [];
+    const gradR: number[][] = [];
+    for (let r = 0; r < rows; r++) {
+      gradC[r] = [];
+      gradR[r] = [];
+      for (let c = 0; c < cols; c++) {
+        gradC[r][c] = c > 0 && c < cols - 1
+          ? (grid[r][c + 1] - grid[r][c - 1]) / 2
+          : c === 0 ? grid[r][1] - grid[r][0] : grid[r][c] - grid[r][c - 1];
+        gradR[r][c] = r > 0 && r < rows - 1
+          ? (grid[r + 1][c] - grid[r - 1][c]) / 2
+          : r === 0 ? grid[1][c] - grid[0][c] : grid[r][c] - grid[r - 1][c];
+      }
+    }
+
+    // --- Vorticity = ∂gradR/∂c - ∂gradC/∂r (curl of gradient) ---
+    const vort: number[][] = [];
+    let maxAbs = 0;
+    for (let r = 0; r < rows; r++) {
+      vort[r] = [];
+      for (let c = 0; c < cols; c++) {
+        const dGradR_dc = c > 0 && c < cols - 1
+          ? (gradR[r][c + 1] - gradR[r][c - 1]) / 2
+          : c === 0 ? gradR[r][1] - gradR[r][0] : gradR[r][c] - gradR[r][c - 1];
+        const dGradC_dr = r > 0 && r < rows - 1
+          ? (gradC[r + 1][c] - gradC[r - 1][c]) / 2
+          : r === 0 ? gradC[1][c] - gradC[0][c] : gradC[r][c] - gradC[r - 1][c];
+        vort[r][c] = dGradR_dc - dGradC_dr;
+        const a = Math.abs(vort[r][c]);
+        if (a > maxAbs) maxAbs = a;
+      }
+    }
+    if (maxAbs < 1e-10) maxAbs = 1;
+
+    // --- Build draped mesh with vertex colors ---
+    // Near-zero vorticity fades toward a neutral grey so only significant
+    // rotation is visually prominent.
+    const geo = new THREE.PlaneGeometry(sceneWidth, sceneDepth, cols - 1, rows - 1);
+    geo.rotateX(-Math.PI / 2);
+
+    const pos = geo.attributes.position;
+    const colors = new Float32Array(pos.count * 3);
+
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        const idx = r * cols + c;
+        const p = grid[r][c];
+        const y = ((p - pressure_min) / pRange) * heightScale + 0.05;
+        pos.setY(idx, y);
+
+        // Normalize vorticity to [0, 1] range centered at 0.5
+        const t = 0.5 + (vort[r][c] / maxAbs) * 0.5;
+        const [cr, cg, cb] = vorticityColor(t);
+
+        // Blend toward neutral grey where vorticity is weak
+        const intensity = Math.abs(vort[r][c]) / maxAbs;
+        const blend = Math.pow(intensity, 1.5); // power curve: only strong vorticity shows
+        const neutral = 0.35; // dark neutral
+        colors[idx * 3] = neutral + (cr - neutral) * blend;
+        colors[idx * 3 + 1] = neutral + (cg - neutral) * blend;
+        colors[idx * 3 + 2] = neutral + (cb - neutral) * blend;
+      }
+    }
+    pos.needsUpdate = true;
+    geo.setAttribute("color", new THREE.BufferAttribute(colors, 3));
+
+    return geo;
+  }, [grid, rows, cols, pressure_min, pressure_max, pRange, heightScale]);
+
+  return (
+    <mesh geometry={geometry}>
+      <meshBasicMaterial
+        vertexColors
+        transparent
+        opacity={opacity}
+        side={THREE.DoubleSide}
+        depthWrite={false}
+      />
+    </mesh>
+  );
+}
+
 function tempColor(t: number): [number, number, number] {
   // Vivid blue (cold, t=0) → purple (mid) → vivid red (hot, t=1)
   // Sigmoid contrast stretch so small deltas produce visible color shifts
@@ -1222,7 +1337,7 @@ function CompassRose({ bearing, isDark }: { bearing: number; isDark: boolean }) 
 // Scene wrapper
 // ---------------------------------------------------------------------------
 
-function PressureFieldScene({ data, isDark, selected, onSelect, rotating, zoom, radarVisible, radarOpacity, radarTs, flowVisible, coriolisEnabled, statesVisible, stationsVisible, tempVisible, tempOpacity, onBearing }: {
+function PressureFieldScene({ data, isDark, selected, onSelect, rotating, zoom, radarVisible, radarOpacity, radarTs, flowVisible, coriolisEnabled, statesVisible, stationsVisible, tempVisible, tempOpacity, vorticityVisible, vorticityOpacity, onBearing }: {
   data: PressureGridData; isDark: boolean;
   selected: StationMarker | null; onSelect: (s: StationMarker | null) => void;
   rotating: boolean; zoom: number;
@@ -1230,6 +1345,7 @@ function PressureFieldScene({ data, isDark, selected, onSelect, rotating, zoom, 
   flowVisible: boolean; coriolisEnabled: boolean;
   statesVisible: boolean; stationsVisible: boolean;
   tempVisible: boolean; tempOpacity: number;
+  vorticityVisible: boolean; vorticityOpacity: number;
   onBearing?: (deg: number) => void;
 }) {
   return (
@@ -1246,6 +1362,7 @@ function PressureFieldScene({ data, isDark, selected, onSelect, rotating, zoom, 
         <PressureSurface data={data} />
         <SideWalls data={data} />
         {tempVisible && <TemperatureOverlay data={data} opacity={tempOpacity} />}
+        {vorticityVisible && <VorticityOverlay data={data} opacity={vorticityOpacity} />}
         {radarVisible && <RadarOverlay data={data} opacity={radarOpacity} radarTs={radarTs} />}
         {flowVisible && <GradientFlowLines data={data} coriolis={coriolisEnabled} />}
         {statesVisible && <StateBoundaryLines data={data} isDark={isDark} />}
@@ -1357,6 +1474,53 @@ function TempScale({ tMin, tMax, isDark, tempUnit }: {
 }
 
 // ---------------------------------------------------------------------------
+// Vorticity color scale — shown when vorticity layer is active
+// ---------------------------------------------------------------------------
+
+function VorticityScale({ isDark, offsetTop }: { isDark: boolean; offsetTop: number }) {
+  // Build CSS gradient matching vorticityColor ramp
+  const stops: string[] = [];
+  for (let i = 0; i <= 10; i++) {
+    const t = i / 10;
+    const [r, g, b] = vorticityColor(t);
+    stops.push(`rgb(${Math.round(r * 255)},${Math.round(g * 255)},${Math.round(b * 255)})`);
+  }
+
+  const panelStyle: React.CSSProperties = {
+    position: "absolute",
+    top: offsetTop,
+    left: 12,
+    zIndex: 10,
+    background: isDark ? "rgba(20, 20, 40, 0.85)" : "rgba(255, 255, 255, 0.9)",
+    border: `1px solid ${isDark ? "rgba(255,255,255,0.1)" : "rgba(0,0,0,0.1)"}`,
+    borderRadius: 8,
+    padding: "8px 12px",
+    color: isDark ? "#ccc" : "#333",
+    fontSize: 11,
+    lineHeight: 1.5,
+    backdropFilter: "blur(8px)",
+    maxWidth: 180,
+  };
+
+  return (
+    <div style={panelStyle}>
+      <div style={{ fontWeight: 600, marginBottom: 3, fontSize: 11 }}>Vorticity</div>
+      <div style={{ fontSize: 10, color: isDark ? "#888" : "#999" }}>Anticyclonic → Cyclonic</div>
+      <div style={{
+        height: 8,
+        borderRadius: 3,
+        background: `linear-gradient(to right, ${stops.join(", ")})`,
+        margin: "3px 0",
+      }} />
+      <div style={{ display: "flex", justifyContent: "space-between", fontSize: 10, color: isDark ? "#888" : "#999" }}>
+        <span>-</span>
+        <span>+</span>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Layers popover panel
 // ---------------------------------------------------------------------------
 
@@ -1368,6 +1532,8 @@ function LayersPanel({ isDark, ...props }: {
   coriolisEnabled: boolean; setCoriolisEnabled: (v: boolean) => void;
   tempVisible: boolean; setTempVisible: (v: boolean) => void;
   tempOpacity: number; setTempOpacity: (v: number) => void;
+  vorticityVisible: boolean; setVorticityVisible: (v: boolean) => void;
+  vorticityOpacity: number; setVorticityOpacity: (v: number) => void;
   statesVisible: boolean; setStatesVisible: (v: boolean) => void;
   stationsVisible: boolean; setStationsVisible: (v: boolean) => void;
 }) {
@@ -1438,6 +1604,20 @@ function LayersPanel({ isDark, ...props }: {
           Coriolis
         </label>
       )}
+
+      {/* Vorticity */}
+      <label style={rowStyle}>
+        <input type="checkbox" checked={props.vorticityVisible}
+          onChange={(e) => props.setVorticityVisible(e.target.checked)}
+          style={{ accentColor: "var(--color-accent)" }} />
+        Vorticity
+        {props.vorticityVisible && (
+          <input type="range" min={0} max={100}
+            value={Math.round(props.vorticityOpacity * 100)}
+            onChange={(e) => props.setVorticityOpacity(Number(e.target.value) / 100)}
+            style={sliderStyle} />
+        )}
+      </label>
 
       {/* Temp */}
       <label style={rowStyle}>
@@ -1568,6 +1748,8 @@ export default function PressureField() {
   const [coriolisEnabled, setCoriolisEnabled] = useState(false);
   const [tempVisible, setTempVisible] = useState(false);
   const [tempOpacity, setTempOpacity] = useState(0.6);
+  const [vorticityVisible, setVorticityVisible] = useState(false);
+  const [vorticityOpacity, setVorticityOpacity] = useState(0.7);
   const [layersOpen, setLayersOpen] = useState(false);
   const [bearing, setBearing] = useState(0);
   const bearingRef = useRef(0);
@@ -1638,7 +1820,7 @@ export default function PressureField() {
 
   return (
     <div style={containerStyle}>
-      <PressureFieldScene data={data} isDark={isDark} selected={selectedStation} onSelect={setSelectedStation} rotating={rotating} zoom={zoom} radarVisible={radarVisible} radarOpacity={radarOpacity} radarTs={radarTs} flowVisible={flowVisible} coriolisEnabled={coriolisEnabled} statesVisible={statesVisible} stationsVisible={stationsVisible} tempVisible={tempVisible} tempOpacity={tempOpacity} onBearing={handleBearing} />
+      <PressureFieldScene data={data} isDark={isDark} selected={selectedStation} onSelect={setSelectedStation} rotating={rotating} zoom={zoom} radarVisible={radarVisible} radarOpacity={radarOpacity} radarTs={radarTs} flowVisible={flowVisible} coriolisEnabled={coriolisEnabled} statesVisible={statesVisible} stationsVisible={stationsVisible} tempVisible={tempVisible} tempOpacity={tempOpacity} vorticityVisible={vorticityVisible} vorticityOpacity={vorticityOpacity} onBearing={handleBearing} />
       <CompassRose bearing={bearing} isDark={isDark} />
       <InfoPanel data={data} isDark={isDark} />
       {/* Temperature color scale — only when temp layer active */}
@@ -1647,6 +1829,7 @@ export default function PressureField() {
         if (temps.length < 2) return null;
         return <TempScale tMin={Math.min(...temps)} tMax={Math.max(...temps)} isDark={isDark} tempUnit={data.temp_unit || "F"} />;
       })()}
+      {vorticityVisible && <VorticityScale isDark={isDark} offsetTop={tempVisible ? 230 : 160} />}
       {/* Minimal scene controls */}
       <div style={{
         position: "absolute",
@@ -1731,6 +1914,8 @@ export default function PressureField() {
           coriolisEnabled={coriolisEnabled} setCoriolisEnabled={setCoriolisEnabled}
           tempVisible={tempVisible} setTempVisible={setTempVisible}
           tempOpacity={tempOpacity} setTempOpacity={setTempOpacity}
+          vorticityVisible={vorticityVisible} setVorticityVisible={setVorticityVisible}
+          vorticityOpacity={vorticityOpacity} setVorticityOpacity={setVorticityOpacity}
           statesVisible={statesVisible} setStatesVisible={setStatesVisible}
           stationsVisible={stationsVisible} setStationsVisible={setStationsVisible}
         />


### PR DESCRIPTION
## Summary
- **Vorticity overlay** — IDW-interpolates observed u/v wind components from ~375 stations onto the 120x120 grid, computes curl (∂v/∂x - ∂u/∂y) for real mesoscale rotation signatures
- Anticyclonic zones in red/orange, cyclonic in cyan/blue, neutral grey where vorticity is weak
- p95 percentile normalization prevents edge artifacts from washing out the interior
- Toggle + opacity slider in Layers panel, color scale legend

Initial attempt used pressure-gradient curl, which is analytically zero for IDW fields (sum of irrotational radial basis functions). Pivoted to wind field curl for ground-truth signal.

Ref #104

## Test plan
- [x] Verified non-zero vorticity signal from live data (375 wind stations)
- [x] Visual confirmation of cyclonic/anticyclonic zones on Windows test box
- [x] `npx tsc --noEmit` clean
- [x] Vite build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)