### PR TITLE
Bridge archive_records into sensor_readings so backfill is visible

### DIFF
--- a/backend/app/services/archive_sync.py
+++ b/backend/app/services/archive_sync.py
@@ -9,13 +9,26 @@ application downtime.
 import asyncio
 import logging
 import struct
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from ..protocol.link_driver import LinkDriver, bcd_decode
 from ..protocol.constants import StationModel, BASIC_STATIONS
 from ..models.database import SessionLocal
 from ..models.archive_record import ArchiveRecordModel
+from ..models.sensor_reading import SensorReadingModel
+from ..utils.units import (
+    f_tenths_to_c_tenths,
+    inhg_thousandths_to_hpa_tenths,
+    mph_to_ms_tenths,
+)
+from .calculations import (
+    dew_point,
+    equivalent_potential_temperature,
+    feels_like,
+    heat_index,
+    wind_chill,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +46,18 @@ ARCHIVE_RECORD_SIZE = {
 
 # Maximum valid SRAM address (0x7F00-0x7FFF reserved for MDMP).
 SRAM_MAX_ADDR = 0x7F00
+
+# Window around an archive record's minute-boundary timestamp inside which
+# any existing sensor_readings row is considered to already cover the period.
+# Archive timestamps are HH:MM:00 (no seconds); live poll timestamps land on
+# arbitrary seconds, so an exact-equality check would never dedupe.
+_DEDUPE_WINDOW = timedelta(seconds=30)
+
+# Compass-rose direction codes (0–15) → degrees, per Davis appendix.txt:F.
+_WIND_DIR_DEGREES = [
+    0, 22, 45, 68, 90, 112, 135, 158,
+    180, 202, 225, 248, 270, 292, 315, 338,
+]
 
 
 # --- Timestamp decoding ---
@@ -244,6 +269,95 @@ def _iter_archive_addresses(
     return addresses
 
 
+# --- archive_records → sensor_readings projection ---
+
+def _project_to_sensor_reading(record: dict) -> SensorReadingModel:
+    """Build a SensorReadingModel from a parsed archive record dict.
+
+    Davis on-device archive records store period aggregates (TinAvg/TOutAvg/
+    WspAvg + THiOut/TLowOut/Gust) in native units (1/10 °F, 1/1000 inHg, mph,
+    compass code 0–15).  This projects the avg/snapshot fields into SI tenths
+    matching sensor_readings, recomputing derived values (heat index, dew
+    point, wind chill, feels-like, theta-e) the same way the live poller does.
+
+    The hi/lo period extremes from archive_records have no home in
+    sensor_readings and are preserved only in archive_records.
+    """
+    inside_temp_c = (
+        f_tenths_to_c_tenths(record["inside_temp_avg"])
+        if record.get("inside_temp_avg") is not None else None
+    )
+    outside_temp_c = (
+        f_tenths_to_c_tenths(record["outside_temp_avg"])
+        if record.get("outside_temp_avg") is not None else None
+    )
+    barometer_hpa = (
+        inhg_thousandths_to_hpa_tenths(record["barometer"])
+        if record.get("barometer") else None
+    )
+    wind_speed_ms = (
+        mph_to_ms_tenths(record["wind_speed_avg"])
+        if record.get("wind_speed_avg") is not None else None
+    )
+    wind_gust_ms = (
+        mph_to_ms_tenths(record["wind_gust"])
+        if record.get("wind_gust") is not None else None
+    )
+    wind_dir_deg = (
+        _WIND_DIR_DEGREES[record["wind_direction"]]
+        if record.get("wind_direction") is not None
+        and 0 <= record["wind_direction"] <= 15
+        else None
+    )
+    outside_hum = record.get("outside_humidity")
+    inside_hum = record.get("inside_humidity")
+    solar_rad = record.get("solar_rad_avg")
+    uv_tenths = (
+        record["uv_avg"]  # already tenths on Health stations
+        if record.get("uv_avg") is not None else None
+    )
+
+    hi = dp = wc = fl = theta = None
+    if outside_temp_c is not None and outside_hum is not None:
+        hi = heat_index(outside_temp_c, outside_hum)
+        dp = dew_point(outside_temp_c, outside_hum)
+        if barometer_hpa is not None:
+            theta = equivalent_potential_temperature(
+                outside_temp_c, outside_hum, barometer_hpa
+            )
+    if outside_temp_c is not None and wind_speed_ms is not None:
+        wc = wind_chill(outside_temp_c, wind_speed_ms)
+    if (outside_temp_c is not None
+            and outside_hum is not None
+            and wind_speed_ms is not None):
+        fl = feels_like(outside_temp_c, outside_hum, wind_speed_ms)
+
+    return SensorReadingModel(
+        timestamp=record["record_time"],
+        station_type=record["station_type"],
+        inside_temp=inside_temp_c,
+        outside_temp=outside_temp_c,
+        inside_humidity=inside_hum,
+        outside_humidity=outside_hum,
+        wind_speed=wind_speed_ms,
+        wind_gust=wind_gust_ms,
+        wind_direction=wind_dir_deg,
+        barometer=barometer_hpa,
+        solar_radiation=solar_rad,
+        uv_index=uv_tenths,
+        heat_index=hi,
+        dew_point=dp,
+        wind_chill=wc,
+        feels_like=fl,
+        theta_e=theta,
+        # Rain fields are intentionally left NULL on backfilled rows:
+        # rain_total is daily-cumulative (needs a known midnight baseline
+        # we can't reconstruct from period deltas across a sleep gap), and
+        # rain_rate would need the rain-collector resolution nibble decoded
+        # against per-station config to be meaningful.
+    )
+
+
 # --- Orchestrator ---
 
 async def async_sync_archive(driver: LinkDriver) -> int:
@@ -329,6 +443,19 @@ async def async_sync_archive(driver: LinkDriver) -> int:
 
             db.add(ArchiveRecordModel(**record))
             inserted += 1
+
+            # Bridge to sensor_readings so the history chart shows the
+            # backfilled interval.  Skip if any live sample already exists
+            # within +/- _DEDUPE_WINDOW of this archive minute — the live
+            # sample is a true instantaneous reading and is preferred over
+            # a derived-from-aggregate row.
+            rt = record["record_time"]
+            has_nearby_reading = db.query(SensorReadingModel.id).filter(
+                SensorReadingModel.timestamp >= rt - _DEDUPE_WINDOW,
+                SensorReadingModel.timestamp <= rt + _DEDUPE_WINDOW,
+            ).first() is not None
+            if not has_nearby_reading:
+                db.add(_project_to_sensor_reading(record))
 
             if inserted % 100 == 0:
                 db.commit()

--- a/backend/logger_main.py
+++ b/backend/logger_main.py
@@ -658,7 +658,13 @@ class LoggerDaemon:
         if not link or not link.connected:
             raise RuntimeError("Not connected (or driver does not support archive force)")
         ok = await link.async_force_archive()
-        return {"success": ok}
+        records_synced = 0
+        if ok:
+            try:
+                records_synced = await async_sync_archive(link)
+            except Exception as exc:
+                logger.warning("Post-force archive sync failed: %s", exc)
+        return {"success": ok, "records_synced": records_synced}
 
 
 # --------------- Entry point ---------------

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -181,7 +181,7 @@ export function clearRainYearly(): Promise<{ success: boolean }> {
   return request("/api/weatherlink/clear-rain-yearly", { method: "POST" });
 }
 
-export function forceArchive(): Promise<{ success: boolean }> {
+export function forceArchive(): Promise<{ success: boolean; records_synced?: number }> {
   return request("/api/weatherlink/force-archive", { method: "POST" });
 }
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -2007,7 +2007,16 @@ export default function Settings() {
     setWlError(null);
     try {
       const resp = await forceArchive();
-      setWlMsg(resp.success ? "Archive record written" : "Failed to write archive");
+      if (resp.success) {
+        const n = resp.records_synced ?? 0;
+        setWlMsg(
+          n > 0
+            ? `Archive record written (${n} new record${n === 1 ? "" : "s"} synced)`
+            : "Archive record written"
+        );
+      } else {
+        setWlMsg("Failed to write archive");
+      }
     } catch (err: unknown) {
       setWlError(err instanceof Error ? err.message : String(err));
     }

--- a/tests/backend/test_archive_sync.py
+++ b/tests/backend/test_archive_sync.py
@@ -1,0 +1,126 @@
+"""Tests for the archive_records -> sensor_readings projection bridge.
+
+The bridge backfills the history chart (which reads only sensor_readings)
+with rows derived from Davis archive records pulled out of the link's SRAM
+during async_sync_archive.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.models.archive_record import ArchiveRecordModel
+from app.models.database import Base, SessionLocal, engine
+from app.models.sensor_reading import SensorReadingModel
+from app.services.archive_sync import _DEDUPE_WINDOW, _project_to_sensor_reading
+from app.utils.units import f_tenths_to_c_tenths, inhg_thousandths_to_hpa_tenths, mph_to_ms_tenths
+
+
+@pytest.fixture(autouse=True)
+def _setup_db():
+    Base.metadata.create_all(bind=engine)
+    yield
+    db = SessionLocal()
+    db.query(SensorReadingModel).delete()
+    db.query(ArchiveRecordModel).delete()
+    db.commit()
+    db.close()
+
+
+def _basic_record(record_time=None, **overrides):
+    """Build a parsed-archive dict matching backend/app/services/archive_sync.py
+    _parse_basic_archive output (Davis native units: 1/10 °F, 1/1000 inHg, mph,
+    %, 0–15 compass code)."""
+    rec = {
+        "archive_address": 0x0000,
+        "record_time": record_time or datetime(2026, 5, 15, 12, 0, 0),
+        "station_type": 16,
+        "barometer": 29920,            # 29.920 inHg
+        "inside_humidity": 45,
+        "outside_humidity": 60,
+        "rain_in_period": 0,
+        "inside_temp_avg": 720,        # 72.0 °F
+        "outside_temp_avg": 680,       # 68.0 °F
+        "wind_speed_avg": 10,          # 10 mph
+        "wind_direction": 4,           # E (90°)
+        "outside_temp_hi": 695,
+        "wind_gust": 18,               # 18 mph
+        "outside_temp_lo": 665,
+    }
+    rec.update(overrides)
+    return rec
+
+
+class TestProjection:
+
+    def test_units_converted_to_si_tenths(self):
+        rec = _basic_record()
+        out = _project_to_sensor_reading(rec)
+
+        assert out.outside_temp == f_tenths_to_c_tenths(680)
+        assert out.inside_temp == f_tenths_to_c_tenths(720)
+        assert out.barometer == inhg_thousandths_to_hpa_tenths(29920)
+        assert out.wind_speed == mph_to_ms_tenths(10)
+        assert out.wind_gust == mph_to_ms_tenths(18)
+        assert out.outside_humidity == 60
+        assert out.inside_humidity == 45
+
+    def test_timestamp_passthrough(self):
+        ts = datetime(2026, 5, 15, 11, 17, 0)
+        out = _project_to_sensor_reading(_basic_record(record_time=ts))
+        assert out.timestamp == ts
+
+    def test_wind_direction_code_to_degrees(self):
+        # Davis compass code 4 == E == 90°, code 8 == S == 180°
+        assert _project_to_sensor_reading(
+            _basic_record(wind_direction=4)).wind_direction == 90
+        assert _project_to_sensor_reading(
+            _basic_record(wind_direction=8)).wind_direction == 180
+        # 0xFF (invalid) parses to None upstream — also handle 0
+        assert _project_to_sensor_reading(
+            _basic_record(wind_direction=0)).wind_direction == 0
+
+    def test_wind_direction_none_when_missing(self):
+        out = _project_to_sensor_reading(_basic_record(wind_direction=None))
+        assert out.wind_direction is None
+
+    def test_derived_fields_computed(self):
+        # Warm-and-humid record should produce a dew point and feels-like.
+        rec = _basic_record(outside_temp_avg=850, outside_humidity=70)  # 85°F/70%
+        out = _project_to_sensor_reading(rec)
+        assert out.dew_point is not None
+        assert out.heat_index is not None
+        assert out.feels_like is not None
+        # theta_e needs baro; baro is provided in _basic_record
+        assert out.theta_e is not None
+
+    def test_wind_chill_only_when_cold_and_windy(self):
+        cold_windy = _basic_record(outside_temp_avg=200, wind_speed_avg=20)  # 20°F/20mph
+        out = _project_to_sensor_reading(cold_windy)
+        assert out.wind_chill is not None
+
+    def test_derived_skipped_when_inputs_missing(self):
+        rec = _basic_record(outside_temp_avg=None, outside_humidity=None)
+        out = _project_to_sensor_reading(rec)
+        assert out.heat_index is None
+        assert out.dew_point is None
+        assert out.feels_like is None
+        assert out.wind_chill is None
+        assert out.theta_e is None
+
+    def test_rain_left_null(self):
+        # Per docstring: backfilled rows don't fill rain_total / rain_rate
+        # because the schema is daily-cumulative / requires resolution decode.
+        out = _project_to_sensor_reading(_basic_record())
+        assert out.rain_total is None
+        assert out.rain_rate is None
+
+
+class TestDedupeWindow:
+    """The bridge skips inserting into sensor_readings when a live reading
+    already exists within ±30 s of the archive minute."""
+
+    def test_window_is_thirty_seconds(self):
+        # Guard against accidental window changes — 30 s matches the granularity
+        # of the live poll cadence vs. minute-boundary archive timestamps.
+        assert _DEDUPE_WINDOW == timedelta(seconds=30)


### PR DESCRIPTION
## Summary

- `archive_sync` now projects each parsed archive record into a `SensorReadingModel` at the same `record_time`, converting Davis native units (1/10 °F, 1/1000 inHg, mph, compass code 0–15) to SI tenths and recomputing dew point / wind chill / heat index / feels-like / theta-e via the same helpers the live poller uses
- `_h_force_archive` triggers `async_sync_archive` after a successful ACK and returns `records_synced`, which the Settings UI surfaces in the button confirmation
- ±30 s dedupe window prevents overwriting genuine live samples with derived-from-aggregate rows where the daemon was running normally

## Why

The history chart, daily extremes, WU/CWOP catchup, and nowcast adapters all read only from `sensor_readings`. `async_sync_archive` was writing only into `archive_records`, so any data pulled from the WeatherLink's SRAM buffer after a downtime gap was invisible to every downstream consumer. Same bug surfaced from the Force Archive button: the `ARC` command was being ACK'd correctly but nothing pulled the resulting SRAM record back, so the UI saw no change despite a true success.

Davis on-device archive semantics confirmed against `reference/techref.txt` lines 2090-2099 (basic), 2367-2370 (GroWeather), 2665-2666 (Energy), 2972-2973 (Health): every layout stores `TinAvg` / `TOutAvg` / `WspAvg` as period aggregates, with `THiOut` / `TLowOut` / `Gust` as separate period extremes. The projection therefore takes the avg fields into the corresponding `sensor_readings` columns (accepting a small fidelity loss at the chosen archive interval) and leaves the period extremes accessible via `archive_records` only.

## Intentional carve-outs

- Rain fields stay NULL on backfilled rows. `rain_total` is daily-cumulative (needs a midnight baseline we can't reconstruct across a sleep gap) and `rain_rate` needs the resolution-nibble decode against per-station config.
- `outside_temp_hi` / `outside_temp_lo` from `archive_records` are not representable in `sensor_readings` so they remain only in `archive_records`.

## Test plan

- [x] `python3 -m pytest ../tests/backend/ -q` → 315 passed (9 new tests in `tests/backend/test_archive_sync.py`)
- [x] `tsc --noEmit` clean
- [x] `python3 -m py_compile backend/app/services/archive_sync.py backend/logger_main.py`
- [ ] On a dev install with a recent downtime gap: restart the daemon and confirm the history chart fills in for the offline period
- [ ] Click "Force Archive" with the daemon connected: button reports a synced count and the new record appears on the chart at the current minute boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)