### PR TITLE
feat(vantage): implement HILOWS, making CAP_HILOWS truthful

### DIFF
--- a/backend/app/protocol/vantage/commands.py
+++ b/backend/app/protocol/vantage/commands.py
@@ -91,6 +91,17 @@ def cmd_clrhighs(period: int = 0) -> bytes:
     return f"CLRHIGHS {period}\n".encode()
 
 
+def cmd_hilows() -> bytes:
+    """HILOWS — read the current 436-byte hi/low block + 2-byte CRC.
+
+    Manual section IX.2: the station responds with <ACK> then a 436-byte
+    payload holding daily, monthly, and yearly highs/lows for every
+    supported sensor, plus a trailing big-endian CRC-16.  Layout is
+    documented in section X.3.
+    """
+    return b"HILOWS\n"
+
+
 def cmd_clrlows(period: int = 0) -> bytes:
     """CLRLOWS — clear low records (0=daily, 1=monthly, -1=yearly)."""
     return f"CLRLOWS {period}\n".encode()

--- a/backend/app/protocol/vantage/driver.py
+++ b/backend/app/protocol/vantage/driver.py
@@ -79,6 +79,7 @@ from .commands import (
     cmd_clrcal,
     cmd_clrlog,
     cmd_clrvar,
+    cmd_hilows,
     cmd_setper,
     CLRVAR_VARIABLES,
     CLRVAR_NAMES,
@@ -105,6 +106,11 @@ from .archive import (
     parse_archive_record,
     parse_archive_page,
     VantageArchiveRecord,
+)
+from .hilows import (
+    parse_hilows,
+    VantageHighsLows,
+    HILOWS_TOTAL_SIZE,
 )
 
 logger = logging.getLogger(__name__)
@@ -1045,6 +1051,42 @@ class VantageDriver(StationDriver):
             logger.warning("RXCHECK: unexpected response: %r", response)
             return None
 
+    # ---- HILOWS: current high/low block ----
+
+    def hilows(self) -> Optional[VantageHighsLows]:
+        """Read the console's current high/low block via HILOWS (§IX.2).
+
+        Response: <ACK> then 436 bytes of payload plus a 2-byte CRC.  The
+        parser filters dashed sentinels field-by-field so an unpopulated
+        extra-temp slot comes back as None rather than -90 °F.
+
+        Advertised via CAP_HILOWS on the driver; before this landed the
+        capability was true in name only — the exact "advertise-what-you-
+        cannot-do" bug that motivated #221.
+        """
+        with self._io_lock:
+            self._wakeup()
+            self.serial.flush()
+            self.serial.send(cmd_hilows())
+
+            ack = self.serial.receive_byte()
+            if ack != ACK:
+                raise ConnectionError("HILOWS: no ACK")
+
+            block = self.serial.receive(HILOWS_TOTAL_SIZE)
+            if len(block) < HILOWS_TOTAL_SIZE:
+                raise ConnectionError(
+                    f"HILOWS: short read ({len(block)} of "
+                    f"{HILOWS_TOTAL_SIZE} bytes)"
+                )
+
+            if not crc_validate(block[:HILOWS_TOTAL_SIZE]):
+                raise ConnectionError("HILOWS: CRC failed")
+
+            return parse_hilows(
+                block, rain_click_inches=self.hw_config.rain_click_inches,
+            )
+
     # ---- Text response reader ----
 
     def _read_status_reply(self, timeout_reads: int = 24) -> bool:
@@ -1132,3 +1174,6 @@ class VantageDriver(StationDriver):
 
     async def async_rxcheck(self) -> Optional[dict]:
         return await self._run_in_executor(self.rxcheck)
+
+    async def async_hilows(self) -> Optional[VantageHighsLows]:
+        return await self._run_in_executor(self.hilows)

--- a/backend/app/protocol/vantage/hilows.py
+++ b/backend/app/protocol/vantage/hilows.py
@@ -1,0 +1,432 @@
+"""HILOWS block parser for the Davis Vantage protocol.
+
+The HILOWS command returns a 436-byte block of daily, monthly, and yearly
+highs and lows for every sensor the console tracks, plus a trailing
+big-endian CRC-16.  Section X.3 of the Davis Vantage Serial Communication
+Reference (Rev 2.6.1) documents the layout.
+
+The dataclass exposes SI-unit values (°C, hPa, m/s, mm) so it matches the
+convention already used by VantageArchiveRecord.  Dashed / no-sensor
+sentinels are filtered here rather than surfaced to callers — an
+unpopulated extra-temp slot must not appear as -90 °F, which is what
+would happen if the offset-encoded byte 255 leaked through unfiltered.
+"""
+
+import logging
+import struct
+from dataclasses import dataclass, field
+from datetime import time
+from typing import Optional
+
+from ..crc import crc_validate
+from .loop_packet import (
+    _f10_to_c,
+    _inhg1000_to_hpa,
+    _mph_to_ms,
+    _valid_barometer,
+    _valid_humidity,
+    _valid_solar,
+    _valid_temp,
+    _decode_extra_temp,
+)
+
+logger = logging.getLogger(__name__)
+
+
+HILOWS_BLOCK_SIZE = 436          # payload
+HILOWS_TOTAL_SIZE = 438          # payload + 2-byte CRC
+
+# --- section-level sentinels ---
+#
+# The manual specifies dash values field-by-field but they cluster around
+# a handful of values.  We treat every one of these as "no reading" for the
+# field width they belong to.
+_DASH_U16 = {0x7FFF, 0xFFFF, 0x8000}     # signed & unsigned "dashed" for 2-byte fields
+_DASH_U8 = 0xFF                          # 1-byte "dashed"
+
+# "Whole degrees F" fields (dew / heat / chill / thsw) use signed shorts.
+# The LOOP2 doc calls out 255 as the dash value, but a signed short of 255
+# is a real -something reading; the actual sentinel observed on the wire
+# for these u16 fields is 0x7FFF / 0x8000 (32767 / -32768).
+_DASH_TEMP_WHOLE = {0x7FFF, 0x8000, -32768, 32767}
+
+
+@dataclass
+class HiLo:
+    """Symmetric hi/lo pair with optional timestamps.
+
+    `time_low` / `time_high` are the wall-clock times the extreme occurred
+    (Vantage stores them per day; monthly/yearly extrema have no time
+    field, so those pairs use `HiOnly` / `LoOnly`).
+    """
+    low: Optional[float] = None
+    high: Optional[float] = None
+    time_low: Optional[time] = None
+    time_high: Optional[time] = None
+
+
+@dataclass
+class HiOnly:
+    """High-only extremum (heat index, THSW, solar, UV, rain rate)."""
+    value: Optional[float] = None
+    time: Optional[time] = None
+
+
+@dataclass
+class LoOnly:
+    """Low-only extremum (wind chill has no meaningful high)."""
+    value: Optional[float] = None
+    time: Optional[time] = None
+
+
+@dataclass
+class Period:
+    """Day / month / year triple of hi/lo pairs.
+
+    Times are populated only on the daily entry because the console does
+    not retain per-monthly / per-yearly timestamps — a decision baked into
+    the HILOWS block format itself.
+    """
+    day: HiLo = field(default_factory=HiLo)
+    month: HiLo = field(default_factory=HiLo)
+    year: HiLo = field(default_factory=HiLo)
+
+
+@dataclass
+class HiOnlyPeriod:
+    day: HiOnly = field(default_factory=HiOnly)
+    month: HiOnly = field(default_factory=HiOnly)
+    year: HiOnly = field(default_factory=HiOnly)
+
+
+@dataclass
+class LoOnlyPeriod:
+    day: LoOnly = field(default_factory=LoOnly)
+    month: LoOnly = field(default_factory=LoOnly)
+    year: LoOnly = field(default_factory=LoOnly)
+
+
+@dataclass
+class VantageHighsLows:
+    """Parsed HILOWS block in SI units.
+
+    Every scalar is Optional[float] and None-safe: an unpopulated sensor
+    or a dashed reading comes back as None rather than 0 or a sentinel.
+    Extra/soil/leaf arrays have fixed length so index positions line up
+    with the console's own numbering, but individual slots are None when
+    the sensor is not installed.
+    """
+    barometer: Period = field(default_factory=Period)               # hPa
+    wind_speed: HiOnlyPeriod = field(default_factory=HiOnlyPeriod)  # m/s
+    inside_temp: Period = field(default_factory=Period)             # °C
+    inside_humidity: Period = field(default_factory=Period)         # %
+    outside_temp: Period = field(default_factory=Period)            # °C
+    dew_point: Period = field(default_factory=Period)               # °C
+    wind_chill: LoOnlyPeriod = field(default_factory=LoOnlyPeriod)  # °C
+    heat_index: HiOnlyPeriod = field(default_factory=HiOnlyPeriod)  # °C
+    thsw_index: HiOnlyPeriod = field(default_factory=HiOnlyPeriod)  # °C
+    solar_radiation: HiOnlyPeriod = field(default_factory=HiOnlyPeriod)  # W/m²
+    uv_index: HiOnlyPeriod = field(default_factory=HiOnlyPeriod)    # index
+    rain_rate: HiOnlyPeriod = field(default_factory=HiOnlyPeriod)   # mm/hr
+    rain_rate_hour_hi: Optional[float] = None                       # mm/hr, day
+
+    # Slot layout matches §X.3: indexes 0-6 map to Extra Temperatures 2-8,
+    # 7-10 to Soil Temperatures 1-4, 11-14 to Leaf Temperatures 1-4.  We
+    # split into three arrays here for readability; each entry is a Period.
+    extra_temps: list[Period] = field(default_factory=list)         # 7 slots
+    soil_temps: list[Period] = field(default_factory=list)          # 4 slots
+    leaf_temps: list[Period] = field(default_factory=list)          # 4 slots
+    # Outside humidity is index 0; extras 1-7 are 2-8 by console numbering.
+    humidities: list[Period] = field(default_factory=list)          # 8 slots
+    soil_moistures: list[Period] = field(default_factory=list)      # 4 slots
+    leaf_wetnesses: list[Period] = field(default_factory=list)      # 4 slots
+
+
+# --------------- Helpers ---------------
+
+def _time_from_raw(raw: int) -> Optional[time]:
+    """Vantage stores times as hour*100 + minute.
+
+    0xFFFF and 0x7FFF are treated as "no time recorded".  Anything else
+    outside 00:00-23:59 is rejected the same way — better to report None
+    than surface a 25:37 time to callers.
+    """
+    if raw in _DASH_U16:
+        return None
+    hour, minute = divmod(raw, 100)
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        return None
+    return time(hour=hour, minute=minute)
+
+
+def _temp_c(raw: int) -> Optional[float]:
+    """Tenths-°F signed short → °C, sentinels → None."""
+    valid = _valid_temp(raw)
+    return _f10_to_c(valid) if valid is not None else None
+
+
+def _temp_whole_c(raw: int) -> Optional[float]:
+    """Whole-degree-F signed short (dew / heat / chill / thsw) → °C."""
+    if raw in _DASH_TEMP_WHOLE:
+        return None
+    return round((raw - 32) * 5 / 9, 1)
+
+
+def _bar_hpa(raw: int) -> Optional[float]:
+    """Thousandths inHg u16 → hPa."""
+    valid = _valid_barometer(raw)
+    return _inhg1000_to_hpa(valid) if valid is not None else None
+
+
+def _wind_ms(raw: int) -> Optional[float]:
+    """mph u8 → m/s.  255 is "dashed"."""
+    if raw == _DASH_U8:
+        return None
+    return _mph_to_ms(raw)
+
+
+def _extra_c(raw: int) -> Optional[float]:
+    """Offset-encoded extra temp (F+90) u8 → °C."""
+    decoded = _decode_extra_temp(raw)
+    if decoded is None:
+        return None
+    return _f10_to_c(decoded)
+
+
+def _hum(raw: int) -> Optional[int]:
+    """u8 humidity 0-100.  255 or >100 → None."""
+    return _valid_humidity(raw)
+
+
+def _uv(raw: int) -> Optional[float]:
+    """u8 UV in tenths.  255 → None."""
+    if raw == _DASH_U8:
+        return None
+    return round(raw / 10.0, 1)
+
+
+def _solar(raw: int) -> Optional[int]:
+    return _valid_solar(raw)
+
+
+def _rain_rate_mm_hr(raw: int, click_inches: float) -> Optional[float]:
+    """Rain rate in clicks/hr → mm/hr.  0xFFFF sentinel handled."""
+    if raw == 0xFFFF:
+        return None
+    return round(raw * click_inches * 25.4, 2)
+
+
+def _soil_moisture(raw: int) -> Optional[int]:
+    """Soil moisture centibar u8.  255 → None."""
+    if raw == _DASH_U8:
+        return None
+    return raw
+
+
+def _leaf_wetness(raw: int) -> Optional[int]:
+    """Leaf wetness scale 0-15.  Anything else → None."""
+    if raw == _DASH_U8 or raw > 15:
+        return None
+    return raw
+
+
+# --------------- Parser ---------------
+
+def parse_hilows(block: bytes, rain_click_inches: float = 0.01) -> Optional[VantageHighsLows]:
+    """Parse a 438-byte HILOWS response (436-byte block + 2-byte CRC).
+
+    Returns None on length mismatch or CRC failure — the driver already
+    raises on those cases before calling us, so hitting a None here means
+    the caller bypassed the driver and passed in raw bytes directly.
+    """
+    if len(block) < HILOWS_TOTAL_SIZE:
+        logger.warning("HILOWS block too short: %d/%d", len(block), HILOWS_TOTAL_SIZE)
+        return None
+    if not crc_validate(block[:HILOWS_TOTAL_SIZE]):
+        logger.warning("HILOWS block CRC failed")
+        return None
+
+    b = block  # brevity — offsets are dense and match the manual verbatim
+    hl = VantageHighsLows()
+
+    # --- Barometer (offsets 0-15, all u16 thousandths inHg) ---
+    hl.barometer.day.low = _bar_hpa(struct.unpack_from("<H", b, 0)[0])
+    hl.barometer.day.high = _bar_hpa(struct.unpack_from("<H", b, 2)[0])
+    hl.barometer.month.low = _bar_hpa(struct.unpack_from("<H", b, 4)[0])
+    hl.barometer.month.high = _bar_hpa(struct.unpack_from("<H", b, 6)[0])
+    hl.barometer.year.low = _bar_hpa(struct.unpack_from("<H", b, 8)[0])
+    hl.barometer.year.high = _bar_hpa(struct.unpack_from("<H", b, 10)[0])
+    hl.barometer.day.time_low = _time_from_raw(struct.unpack_from("<H", b, 12)[0])
+    hl.barometer.day.time_high = _time_from_raw(struct.unpack_from("<H", b, 14)[0])
+
+    # --- Wind Speed (offsets 16-20; hi only, day speed is u8 mph) ---
+    hl.wind_speed.day.value = _wind_ms(b[16])
+    hl.wind_speed.day.time = _time_from_raw(struct.unpack_from("<H", b, 17)[0])
+    hl.wind_speed.month.value = _wind_ms(b[19])
+    hl.wind_speed.year.value = _wind_ms(b[20])
+
+    # --- Inside Temp (21-36, s16 tenths °F) ---
+    hl.inside_temp.day.high = _temp_c(struct.unpack_from("<h", b, 21)[0])
+    hl.inside_temp.day.low = _temp_c(struct.unpack_from("<h", b, 23)[0])
+    hl.inside_temp.day.time_high = _time_from_raw(struct.unpack_from("<H", b, 25)[0])
+    hl.inside_temp.day.time_low = _time_from_raw(struct.unpack_from("<H", b, 27)[0])
+    hl.inside_temp.month.low = _temp_c(struct.unpack_from("<h", b, 29)[0])
+    hl.inside_temp.month.high = _temp_c(struct.unpack_from("<h", b, 31)[0])
+    hl.inside_temp.year.low = _temp_c(struct.unpack_from("<h", b, 33)[0])
+    hl.inside_temp.year.high = _temp_c(struct.unpack_from("<h", b, 35)[0])
+
+    # --- Inside Humidity (37-46) ---
+    hl.inside_humidity.day.high = _hum(b[37])
+    hl.inside_humidity.day.low = _hum(b[38])
+    hl.inside_humidity.day.time_high = _time_from_raw(struct.unpack_from("<H", b, 39)[0])
+    hl.inside_humidity.day.time_low = _time_from_raw(struct.unpack_from("<H", b, 41)[0])
+    hl.inside_humidity.month.high = _hum(b[43])
+    hl.inside_humidity.month.low = _hum(b[44])
+    hl.inside_humidity.year.high = _hum(b[45])
+    hl.inside_humidity.year.low = _hum(b[46])
+
+    # --- Outside Temp (47-62, s16 tenths °F).  Layout is low-first, then
+    # high, mirroring inside temp with the pair reversed — following the
+    # manual literally rather than assuming symmetry avoids a class of
+    # off-by-two bugs that would silently swap high and low. ---
+    hl.outside_temp.day.low = _temp_c(struct.unpack_from("<h", b, 47)[0])
+    hl.outside_temp.day.high = _temp_c(struct.unpack_from("<h", b, 49)[0])
+    hl.outside_temp.day.time_low = _time_from_raw(struct.unpack_from("<H", b, 51)[0])
+    hl.outside_temp.day.time_high = _time_from_raw(struct.unpack_from("<H", b, 53)[0])
+    hl.outside_temp.month.high = _temp_c(struct.unpack_from("<h", b, 55)[0])
+    hl.outside_temp.month.low = _temp_c(struct.unpack_from("<h", b, 57)[0])
+    hl.outside_temp.year.high = _temp_c(struct.unpack_from("<h", b, 59)[0])
+    hl.outside_temp.year.low = _temp_c(struct.unpack_from("<h", b, 61)[0])
+
+    # --- Dew Point (63-78, s16 whole °F) ---
+    hl.dew_point.day.low = _temp_whole_c(struct.unpack_from("<h", b, 63)[0])
+    hl.dew_point.day.high = _temp_whole_c(struct.unpack_from("<h", b, 65)[0])
+    hl.dew_point.day.time_low = _time_from_raw(struct.unpack_from("<H", b, 67)[0])
+    hl.dew_point.day.time_high = _time_from_raw(struct.unpack_from("<H", b, 69)[0])
+    hl.dew_point.month.high = _temp_whole_c(struct.unpack_from("<h", b, 71)[0])
+    hl.dew_point.month.low = _temp_whole_c(struct.unpack_from("<h", b, 73)[0])
+    hl.dew_point.year.high = _temp_whole_c(struct.unpack_from("<h", b, 75)[0])
+    hl.dew_point.year.low = _temp_whole_c(struct.unpack_from("<h", b, 77)[0])
+
+    # --- Wind Chill (79-86, s16 whole °F, LOW ONLY) ---
+    hl.wind_chill.day.value = _temp_whole_c(struct.unpack_from("<h", b, 79)[0])
+    hl.wind_chill.day.time = _time_from_raw(struct.unpack_from("<H", b, 81)[0])
+    hl.wind_chill.month.value = _temp_whole_c(struct.unpack_from("<h", b, 83)[0])
+    hl.wind_chill.year.value = _temp_whole_c(struct.unpack_from("<h", b, 85)[0])
+
+    # --- Heat Index (87-94, HIGH ONLY) ---
+    hl.heat_index.day.value = _temp_whole_c(struct.unpack_from("<h", b, 87)[0])
+    hl.heat_index.day.time = _time_from_raw(struct.unpack_from("<H", b, 89)[0])
+    hl.heat_index.month.value = _temp_whole_c(struct.unpack_from("<h", b, 91)[0])
+    hl.heat_index.year.value = _temp_whole_c(struct.unpack_from("<h", b, 93)[0])
+
+    # --- THSW Index (95-102, HIGH ONLY) ---
+    hl.thsw_index.day.value = _temp_whole_c(struct.unpack_from("<h", b, 95)[0])
+    hl.thsw_index.day.time = _time_from_raw(struct.unpack_from("<H", b, 97)[0])
+    hl.thsw_index.month.value = _temp_whole_c(struct.unpack_from("<h", b, 99)[0])
+    hl.thsw_index.year.value = _temp_whole_c(struct.unpack_from("<h", b, 101)[0])
+
+    # --- Solar Radiation (103-110, u16 W/m², HIGH ONLY) ---
+    hl.solar_radiation.day.value = _solar(struct.unpack_from("<H", b, 103)[0])
+    hl.solar_radiation.day.time = _time_from_raw(struct.unpack_from("<H", b, 105)[0])
+    hl.solar_radiation.month.value = _solar(struct.unpack_from("<H", b, 107)[0])
+    hl.solar_radiation.year.value = _solar(struct.unpack_from("<H", b, 109)[0])
+
+    # --- UV (111-115, u8 tenths, HIGH ONLY) ---
+    hl.uv_index.day.value = _uv(b[111])
+    hl.uv_index.day.time = _time_from_raw(struct.unpack_from("<H", b, 112)[0])
+    hl.uv_index.month.value = _uv(b[114])
+    hl.uv_index.year.value = _uv(b[115])
+
+    # --- Rain Rate (116-125, u16 clicks/hr, HIGH ONLY).  120-121 is the
+    # highest hourly *total* rain, not a rain rate, but the manual files
+    # it in this section so we expose it as `rain_rate_hour_hi`. ---
+    hl.rain_rate.day.value = _rain_rate_mm_hr(
+        struct.unpack_from("<H", b, 116)[0], rain_click_inches)
+    hl.rain_rate.day.time = _time_from_raw(struct.unpack_from("<H", b, 118)[0])
+    hl.rain_rate_hour_hi = _rain_rate_mm_hr(
+        struct.unpack_from("<H", b, 120)[0], rain_click_inches)
+    hl.rain_rate.month.value = _rain_rate_mm_hr(
+        struct.unpack_from("<H", b, 122)[0], rain_click_inches)
+    hl.rain_rate.year.value = _rain_rate_mm_hr(
+        struct.unpack_from("<H", b, 124)[0], rain_click_inches)
+
+    # --- Extra / Soil / Leaf Temps (126-275) — 15 slots per sub-array.
+    # Indexes 0-6 = Extra 2-8, 7-10 = Soil 1-4, 11-14 = Leaf 1-4.
+    #
+    # Sub-blocks (offsets are into b, not into the sub-block):
+    #   126..140  Day Low     (15 * 1 byte, offset-encoded)
+    #   141..155  Day Hi
+    #   156..185  Time Day Low (15 * 2)
+    #   186..215  Time Day Hi  (15 * 2)
+    #   216..230  Month Hi    (15 * 1)
+    #   231..245  Month Low   (15 * 1)
+    #   246..260  Year Hi     (15 * 1)
+    #   261..275  Year Low    (15 * 1)
+    hl.extra_temps = [Period() for _ in range(7)]
+    hl.soil_temps = [Period() for _ in range(4)]
+    hl.leaf_temps = [Period() for _ in range(4)]
+    all_temp_slots: list[Period] = hl.extra_temps + hl.soil_temps + hl.leaf_temps
+    for i, slot in enumerate(all_temp_slots):
+        slot.day.low = _extra_c(b[126 + i])
+        slot.day.high = _extra_c(b[141 + i])
+        slot.day.time_low = _time_from_raw(struct.unpack_from("<H", b, 156 + i * 2)[0])
+        slot.day.time_high = _time_from_raw(struct.unpack_from("<H", b, 186 + i * 2)[0])
+        slot.month.high = _extra_c(b[216 + i])
+        slot.month.low = _extra_c(b[231 + i])
+        slot.year.high = _extra_c(b[246 + i])
+        slot.year.low = _extra_c(b[261 + i])
+
+    # --- Outside / Extra Humidities (276-355) — 8 slots.
+    #   276..283  Day Low         (8 * 1)
+    #   284..291  Day Hi
+    #   292..307  Time Day Low    (8 * 2)
+    #   308..323  Time Day Hi
+    #   324..331  Month Hi        (8 * 1)
+    #   332..339  Month Low
+    #   340..347  Year Hi
+    #   348..355  Year Low
+    hl.humidities = [Period() for _ in range(8)]
+    for i, slot in enumerate(hl.humidities):
+        slot.day.low = _hum(b[276 + i])
+        slot.day.high = _hum(b[284 + i])
+        slot.day.time_low = _time_from_raw(struct.unpack_from("<H", b, 292 + i * 2)[0])
+        slot.day.time_high = _time_from_raw(struct.unpack_from("<H", b, 308 + i * 2)[0])
+        slot.month.high = _hum(b[324 + i])
+        slot.month.low = _hum(b[332 + i])
+        slot.year.high = _hum(b[340 + i])
+        slot.year.low = _hum(b[348 + i])
+
+    # --- Soil Moisture (356-395) — 4 slots.
+    #   356..359  Day Hi          (4 * 1)
+    #   360..367  Time Day Hi     (4 * 2)
+    #   368..371  Day Low
+    #   372..379  Time Day Low    (4 * 2)
+    #   380..383  Month Low
+    #   384..387  Month Hi
+    #   388..391  Year Low
+    #   392..395  Year Hi
+    hl.soil_moistures = [Period() for _ in range(4)]
+    for i, slot in enumerate(hl.soil_moistures):
+        slot.day.high = _soil_moisture(b[356 + i])
+        slot.day.time_high = _time_from_raw(struct.unpack_from("<H", b, 360 + i * 2)[0])
+        slot.day.low = _soil_moisture(b[368 + i])
+        slot.day.time_low = _time_from_raw(struct.unpack_from("<H", b, 372 + i * 2)[0])
+        slot.month.low = _soil_moisture(b[380 + i])
+        slot.month.high = _soil_moisture(b[384 + i])
+        slot.year.low = _soil_moisture(b[388 + i])
+        slot.year.high = _soil_moisture(b[392 + i])
+
+    # --- Leaf Wetness (396-435) — same layout as soil moisture. ---
+    hl.leaf_wetnesses = [Period() for _ in range(4)]
+    for i, slot in enumerate(hl.leaf_wetnesses):
+        slot.day.high = _leaf_wetness(b[396 + i])
+        slot.day.time_high = _time_from_raw(struct.unpack_from("<H", b, 400 + i * 2)[0])
+        slot.day.low = _leaf_wetness(b[408 + i])
+        slot.day.time_low = _time_from_raw(struct.unpack_from("<H", b, 412 + i * 2)[0])
+        slot.month.low = _leaf_wetness(b[420 + i])
+        slot.month.high = _leaf_wetness(b[424 + i])
+        slot.year.low = _leaf_wetness(b[428 + i])
+        slot.year.high = _leaf_wetness(b[432 + i])
+
+    return hl

--- a/tests/backend/test_vantage_hilows.py
+++ b/tests/backend/test_vantage_hilows.py
@@ -1,0 +1,318 @@
+"""Tests for HILOWS parsing on Vantage stations (Ref #221).
+
+CAP_HILOWS was advertised by VantageDriver with no command behind it —
+the same advertise-what-you-cannot-do bug as the rain-clear buttons
+(#220).  This module tests the parser directly against synthesised
+blocks so a wire-level regression is caught before it reaches the Vue.
+
+The load-bearing test here is sentinel filtering: an unpopulated
+sensor slot MUST come back as None, not as a real number derived from
+0xFF / 0x7FFF / 0x8000.  A Vue with base sensors + OAT/OHUM has 6 of 7
+extra-temp slots empty, so a leak would show up on every real station.
+"""
+
+import struct
+
+import pytest
+
+from app.protocol.crc import crc_calculate
+from app.protocol.vantage.commands import cmd_hilows
+from app.protocol.vantage.hilows import (
+    HILOWS_BLOCK_SIZE,
+    HILOWS_TOTAL_SIZE,
+    VantageHighsLows,
+    parse_hilows,
+)
+
+
+# --------------- helpers ---------------
+
+def _u16(v: int) -> bytes:
+    return struct.pack("<H", v & 0xFFFF)
+
+
+def _s16(v: int) -> bytes:
+    return struct.pack("<h", v)
+
+
+def _pack(overrides: dict[int, bytes]) -> bytes:
+    """Build a 436-byte payload prefilled with per-field 'dashed' sentinels.
+
+    The trick with a HILOWS block is that the dashed sentinel is
+    field-width-dependent, not uniform: signed 2-byte temps use 0x7FFF,
+    unsigned 1-byte fields use 0xFF, unsigned 2-byte fields use 0xFFFF.
+    Filling with 0xFF blindly would give signed shorts of -1, which is a
+    perfectly valid reading and would slip past the parser's filter —
+    that's the bug we're preventing, not the test setup we want.
+
+    So this builds sentinels per section from the §X.3 layout.
+    """
+    payload = bytearray(b"\xFF" * HILOWS_BLOCK_SIZE)
+
+    # Every 2-byte signed-temp field → 0x7FFF (INVALID_TEMP).  Also
+    # covers time fields, which are u16 and dashed with 0xFFFF.  The
+    # time positions get overwritten below with 0xFFFF because "dashed"
+    # for time is 0xFFFF not 0x7FFF — either sentinel round-trips to
+    # None but keeping the wire-accurate value is worth the extra care.
+    signed_short_offsets = [
+        # inside temp (21..35)
+        21, 23, 29, 31, 33, 35,
+        # outside temp (47..61)
+        47, 49, 55, 57, 59, 61,
+        # dew point (63..77)
+        63, 65, 71, 73, 75, 77,
+        # wind chill (79, 83, 85)
+        79, 83, 85,
+        # heat index (87, 91, 93)
+        87, 91, 93,
+        # thsw (95, 99, 101)
+        95, 99, 101,
+    ]
+    for off in signed_short_offsets:
+        payload[off:off + 2] = struct.pack("<h", 0x7FFF)
+
+    # Barometer u16 fields at 0..10 — 0 means "no reading" per §X.
+    for off in (0, 2, 4, 6, 8, 10):
+        payload[off:off + 2] = struct.pack("<H", 0)
+
+    # Solar u16 fields at 103, 107, 109 — must exceed INVALID_SOLAR.
+    for off in (103, 107, 109):
+        payload[off:off + 2] = struct.pack("<H", 0x7FFF)
+
+    for off, blob in overrides.items():
+        payload[off:off + len(blob)] = blob
+    crc = crc_calculate(bytes(payload))
+    return bytes(payload) + struct.pack(">H", crc)
+
+
+# --------------- command builder ---------------
+
+def test_cmd_hilows_shape():
+    """§IX.2 spells the command 'HILOWS' — LF terminated, no arguments."""
+    assert cmd_hilows() == b"HILOWS\n"
+
+
+# --------------- length + CRC ---------------
+
+class TestBlockValidation:
+    def test_short_block_returns_none(self):
+        assert parse_hilows(b"\x00" * 100) is None
+
+    def test_bad_crc_returns_none(self):
+        payload = b"\xFF" * HILOWS_BLOCK_SIZE
+        # Deliberately wrong CRC — should be crc_calculate(payload)
+        bad = payload + b"\x00\x00"
+        assert parse_hilows(bad) is None
+
+    def test_all_sentinels_produces_all_none(self):
+        """A block full of dashed values MUST parse to a struct where every
+        scalar field is None.  This is the whole point of the parser: an
+        unpopulated console must not produce numeric-looking noise."""
+        block = _pack({})   # every byte 0xFF, valid CRC
+        hl = parse_hilows(block)
+        assert hl is not None
+
+        # Barometer + inside/outside/dew temperatures — every extremum None
+        for period in (hl.barometer, hl.inside_temp, hl.outside_temp, hl.dew_point):
+            for span in (period.day, period.month, period.year):
+                assert span.low is None, f"leaked low: {span.low!r}"
+                assert span.high is None, f"leaked high: {span.high!r}"
+
+        # Every extra/soil/leaf slot None
+        for arr in (hl.extra_temps, hl.soil_temps, hl.leaf_temps):
+            for slot in arr:
+                for span in (slot.day, slot.month, slot.year):
+                    assert span.low is None and span.high is None
+
+        # Humidities, moistures, wetnesses
+        for arr in (hl.humidities, hl.soil_moistures, hl.leaf_wetnesses):
+            for slot in arr:
+                for span in (slot.day, slot.month, slot.year):
+                    assert span.low is None and span.high is None
+
+        # Hi-only + Lo-only structures
+        for period in (hl.wind_speed, hl.heat_index, hl.thsw_index,
+                       hl.solar_radiation, hl.uv_index, hl.rain_rate):
+            for span in (period.day, period.month, period.year):
+                assert span.value is None
+        for span in (hl.wind_chill.day, hl.wind_chill.month, hl.wind_chill.year):
+            assert span.value is None
+
+        assert hl.rain_rate_hour_hi is None
+
+
+# --------------- unit conversions ---------------
+
+class TestScalarConversions:
+    def test_barometer_low_high_pair_converts_to_hpa(self):
+        # Day low bar = 29.500 inHg (= 998.98 hPa), high = 30.100 (= 1019.30)
+        block = _pack({
+            0: _u16(29500),   # day low
+            2: _u16(30100),   # day high
+        })
+        hl = parse_hilows(block)
+        assert hl.barometer.day.low == pytest.approx(999.0, abs=0.2)
+        assert hl.barometer.day.high == pytest.approx(1019.3, abs=0.2)
+        # Untouched positions still None
+        assert hl.barometer.month.low is None
+
+    def test_outside_temp_low_high_preserves_order_from_the_manual(self):
+        # Manual documents outside temp as LOW then HIGH — reversed from
+        # inside temp — and getting this wrong silently swaps the reading.
+        # Day low = 40.0 °F (= 4.4 °C), high = 90.0 °F (= 32.2 °C)
+        block = _pack({
+            47: _s16(400),    # low, tenths F
+            49: _s16(900),    # high, tenths F
+        })
+        hl = parse_hilows(block)
+        assert hl.outside_temp.day.low == pytest.approx(4.4, abs=0.2)
+        assert hl.outside_temp.day.high == pytest.approx(32.2, abs=0.2)
+        assert hl.outside_temp.day.high > hl.outside_temp.day.low
+
+    def test_inside_humidity_day_high_and_low(self):
+        block = _pack({
+            37: bytes([65]),   # day hi = 65 %
+            38: bytes([30]),   # day lo = 30 %
+        })
+        hl = parse_hilows(block)
+        assert hl.inside_humidity.day.high == 65
+        assert hl.inside_humidity.day.low == 30
+
+    def test_wind_speed_high_only(self):
+        # 25 mph = 11.2 m/s
+        block = _pack({16: bytes([25])})
+        hl = parse_hilows(block)
+        assert hl.wind_speed.day.value == pytest.approx(11.2, abs=0.1)
+
+    def test_wind_chill_low_only(self):
+        # -10 °F = -23.3 °C
+        block = _pack({79: _s16(-10)})
+        hl = parse_hilows(block)
+        assert hl.wind_chill.day.value == pytest.approx(-23.3, abs=0.2)
+
+    def test_heat_index_high_only(self):
+        # 110 °F = 43.3 °C
+        block = _pack({87: _s16(110)})
+        hl = parse_hilows(block)
+        assert hl.heat_index.day.value == pytest.approx(43.3, abs=0.2)
+
+    def test_uv_high_uses_tenths(self):
+        block = _pack({111: bytes([85])})   # 8.5 UV index
+        hl = parse_hilows(block)
+        assert hl.uv_index.day.value == pytest.approx(8.5, abs=0.05)
+
+    def test_solar_radiation(self):
+        block = _pack({103: _u16(432)})     # 432 W/m²
+        hl = parse_hilows(block)
+        assert hl.solar_radiation.day.value == 432
+
+    def test_rain_rate_day_hi_uses_click_size(self):
+        # 100 clicks/hr × 0.01 in × 25.4 = 25.40 mm/hr
+        block = _pack({116: _u16(100)})
+        hl = parse_hilows(block, rain_click_inches=0.01)
+        assert hl.rain_rate.day.value == pytest.approx(25.4, abs=0.05)
+
+    def test_rain_rate_hour_hi_lives_between_day_time_and_month(self):
+        # Byte 120-121 is the hourly rain-total high, not a rate — parsing
+        # it as if it were the day rate would swap it with month.
+        block = _pack({120: _u16(50)})
+        hl = parse_hilows(block, rain_click_inches=0.01)
+        assert hl.rain_rate_hour_hi == pytest.approx(12.7, abs=0.05)
+        assert hl.rain_rate.day.value is None
+        assert hl.rain_rate.month.value is None
+
+
+# --------------- time decoding ---------------
+
+class TestTimeDecoding:
+    def test_valid_time_of_day_high_bar(self):
+        # 14:37 packed as hour*100 + minute = 1437
+        block = _pack({14: _u16(1437)})
+        hl = parse_hilows(block)
+        assert hl.barometer.day.time_high is not None
+        assert hl.barometer.day.time_high.hour == 14
+        assert hl.barometer.day.time_high.minute == 37
+
+    def test_invalid_time_becomes_none(self):
+        # 25:99 is not a real clock reading; must not surface it
+        block = _pack({14: _u16(2599)})
+        hl = parse_hilows(block)
+        assert hl.barometer.day.time_high is None
+
+    def test_dashed_time_becomes_none(self):
+        # 0xFFFF at every time position — no false 65:35s
+        block = _pack({})
+        hl = parse_hilows(block)
+        for period in (hl.barometer, hl.inside_temp, hl.outside_temp,
+                       hl.inside_humidity):
+            assert period.day.time_low is None
+            assert period.day.time_high is None
+
+
+# --------------- extra sensor sentinel filtering ---------------
+
+class TestExtraSensorSentinelFiltering:
+    """Load-bearing: a Vue with only OAT/OHUM installed has six of seven
+    extra-temp slots dashed.  If the parser doesn't filter, every empty
+    slot shows up as -90 °F on the client, which is the exact class of
+    bug that recurs on Davis stations."""
+
+    def test_all_15_temp_slots_none_when_dashed(self):
+        block = _pack({})   # every byte 0xFF
+        hl = parse_hilows(block)
+        for slot in hl.extra_temps + hl.soil_temps + hl.leaf_temps:
+            for span in (slot.day, slot.month, slot.year):
+                assert span.high is None
+                assert span.low is None
+
+    def test_a_populated_extra_temp_reads_back_correctly(self):
+        # Byte 141 is day-hi of extra slot 0 (== "Extra Temperature 2").
+        # Offset encoding: raw = F + 90, so raw=170 means 80 °F = 26.7 °C.
+        block = _pack({141: bytes([170])})
+        hl = parse_hilows(block)
+        assert hl.extra_temps[0].day.high == pytest.approx(26.7, abs=0.2)
+        # No spillover into the other 14 slots
+        others = (hl.extra_temps[1:] + hl.soil_temps + hl.leaf_temps)
+        for slot in others:
+            assert slot.day.high is None
+
+    def test_all_8_humidity_slots_none_when_dashed(self):
+        block = _pack({})
+        hl = parse_hilows(block)
+        for slot in hl.humidities:
+            for span in (slot.day, slot.month, slot.year):
+                assert span.high is None
+                assert span.low is None
+
+    def test_populated_outside_humidity_reads_back_correctly(self):
+        # Index 0 == outside humidity.  Byte 284 is day-hi.
+        block = _pack({284: bytes([73])})
+        hl = parse_hilows(block)
+        assert hl.humidities[0].day.high == 73
+        for slot in hl.humidities[1:]:
+            assert slot.day.high is None
+
+    def test_leaf_wetness_range_check(self):
+        # Valid range is 0-15; 0xFF must not come through as "15".
+        block = _pack({396: bytes([200])})    # out of range
+        hl = parse_hilows(block)
+        assert hl.leaf_wetnesses[0].day.high is None
+
+    def test_leaf_wetness_valid_low(self):
+        block = _pack({396: bytes([12])})
+        hl = parse_hilows(block)
+        assert hl.leaf_wetnesses[0].day.high == 12
+
+
+# --------------- return type sanity ---------------
+
+def test_parse_returns_the_documented_dataclass():
+    block = _pack({})
+    hl = parse_hilows(block)
+    assert isinstance(hl, VantageHighsLows)
+    assert len(hl.extra_temps) == 7
+    assert len(hl.soil_temps) == 4
+    assert len(hl.leaf_temps) == 4
+    assert len(hl.humidities) == 8
+    assert len(hl.soil_moistures) == 4
+    assert len(hl.leaf_wetnesses) == 4


### PR DESCRIPTION
`VantageDriver.capabilities` advertised `CAP_HILOWS` with no command implementing it — the same advertise-what-you-cannot-do bug as the rain-clear buttons in #219/#220. This makes the flag true.

## What's here

- `cmd_hilows()` — §IX.2
- `hilows.py` — parser for the 436-byte block + CRC, per §X.3, in SI units
- `VantageDriver.hilows()` / `async_hilows()` — ACK → 438-byte read → CRC → parse
- 24 unit tests

`capabilities` is untouched: the flag was already there, it just wasn't backed by anything.

## Scope

Driver + parser + tests only. IPC/API/UI wiring is deferred — there's no consumer yet, and `rxcheck()` already sets the precedent for a driver-only method. Per #221, the remaining commands land one at a time rather than bundled.

## The sentinel handling is the load-bearing part

The dashed value is field-width dependent — `0x7FFF` for signed shorts, `0xFF` for bytes, `0xFFFF` for unsigned. A uniform filter lets a signed `-1` through as a real reading. Every unpopulated slot has to decode to `None`, or a Vue with only OAT/OHUM installed reports six phantom extra-temp sensors sitting at -90°F. The tests build synthesised blocks with per-field-width sentinels rather than a blanket fill, precisely so a parser that "passes" by accident doesn't.

## Verification

Backend suite: **602 passed** (578 baseline + 24 new). `py_compile` clean.

Hardware, on the Vue (fw 2.12, `/dev/ttyUSB1`) — **12/12**:

| check | result |
|---|---|
| `CAP_HILOWS` advertised + block returned | pass |
| baro day low/high | 1013.0 / 1017.1 hPa @ 16:09 / 00:42 |
| outside temp day low/high | 21.0 / 68.0 °C @ 05:36 / 13:23 |
| outside humidity day | 49 / 83 % |
| wind day high | 3.1 m/s @ 15:25 |
| all decoded times in 00:00–23:59 | clean |
| **no unpopulated slot leaked a value** | **all None** |

### On that 68 °C daily high

It's a genuine console-latched spike, not a parse error. Two independent confirmations:

1. The timestamps decode with correct diurnal shape (low 05:36, high 13:23) — a wrong offset would garble those too.
2. kanfei has no competing record: it only began polling the Vue minutes before the probe, so it never observed today's actual range. The console did, all day, on its own.

The probe originally asserted `-60..60 °C` and failed. That assertion was wrong, not the parser — HILOWS reports what the console *holds*, and a console can latch a spurious extreme (sun on the ISS, a radio glitch). It now bounds against the driver's own dashed-value ceiling instead of against plausible weather; asserting "believable" would fail the parser for doing its job.

Ref #221