### PR TITLE
feat(vantage): implement CLRHIGHS/CLRLOWS, and fix the period argument

### DIFF
--- a/backend/app/protocol/vantage/commands.py
+++ b/backend/app/protocol/vantage/commands.py
@@ -86,8 +86,31 @@ def cmd_clrlog() -> bytes:
     return b"CLRLOG\n"
 
 
-def cmd_clrhighs(period: int = 0) -> bytes:
-    """CLRHIGHS — clear high records (0=daily, 1=monthly, -1=yearly)."""
+# --------------- CLRHIGHS / CLRLOWS periods ---------------
+# Manual sections IX.6 / IX.13: the argument is 0, 1, or 2.  An earlier
+# docstring here claimed -1 meant yearly; that is wrong and would have put
+# an undefined value on the wire.  Nothing called it, so nothing broke.
+#
+# These clear *every* extremum for the period.  Per section II.4, "You can
+# not reset individual high or low values" — there is no way to clear just
+# one sensor's high, so callers must accept the collateral.
+CLR_PERIOD_DAILY = 0
+CLR_PERIOD_MONTHLY = 1
+CLR_PERIOD_YEARLY = 2
+
+CLR_PERIODS: frozenset[int] = frozenset({
+    CLR_PERIOD_DAILY, CLR_PERIOD_MONTHLY, CLR_PERIOD_YEARLY,
+})
+
+CLR_PERIOD_NAMES: dict[int, str] = {
+    CLR_PERIOD_DAILY: "daily",
+    CLR_PERIOD_MONTHLY: "monthly",
+    CLR_PERIOD_YEARLY: "yearly",
+}
+
+
+def cmd_clrhighs(period: int = CLR_PERIOD_DAILY) -> bytes:
+    """CLRHIGHS — clear ALL high records for a period (0/1/2)."""
     return f"CLRHIGHS {period}\n".encode()
 
 
@@ -102,8 +125,8 @@ def cmd_hilows() -> bytes:
     return b"HILOWS\n"
 
 
-def cmd_clrlows(period: int = 0) -> bytes:
-    """CLRLOWS — clear low records (0=daily, 1=monthly, -1=yearly)."""
+def cmd_clrlows(period: int = CLR_PERIOD_DAILY) -> bytes:
+    """CLRLOWS — clear ALL low records for a period (0/1/2)."""
     return f"CLRLOWS {period}\n".encode()
 
 

--- a/backend/app/protocol/vantage/driver.py
+++ b/backend/app/protocol/vantage/driver.py
@@ -79,12 +79,17 @@ from .commands import (
     cmd_clrcal,
     cmd_clrlog,
     cmd_clrvar,
+    cmd_clrhighs,
+    cmd_clrlows,
     cmd_hilows,
     cmd_setper,
     CLRVAR_VARIABLES,
     CLRVAR_NAMES,
     CLRVAR_RAIN_DAILY,
     CLRVAR_RAIN_YEAR,
+    CLR_PERIODS,
+    CLR_PERIOD_NAMES,
+    CLR_PERIOD_DAILY,
     build_dmpaft_timestamp,
     build_settime_payload,
 )
@@ -793,8 +798,66 @@ class VantageDriver(StationDriver):
         """Clear the yearly rain accumulator (CLRVAR 17)."""
         return self.clear_variable(CLRVAR_RAIN_YEAR)
 
+    def clear_highs(self, period: int = CLR_PERIOD_DAILY) -> bool:
+        """CLRHIGHS — clear ALL high records for a period.  **IRREVERSIBLE.**
+
+        `period` is 0 daily / 1 monthly / 2 yearly (manual section IX.13).
+
+        This is deliberately not scoped to a single sensor, because the
+        protocol cannot do that: section II.4 states "You can not reset
+        individual high or low values."  Clearing the daily highs to drop
+        one bad reading also drops that day's barometer, wind, humidity and
+        inside-temperature highs.  Callers wanting to remove a single
+        outlier should know they are trading the whole period for it.
+        """
+        if period not in CLR_PERIODS:
+            raise ValueError(
+                f"CLRHIGHS period must be one of {sorted(CLR_PERIODS)} "
+                f"(got {period})"
+            )
+        name = CLR_PERIOD_NAMES.get(period, str(period))
+        with self._io_lock:
+            self._wakeup()
+            self.serial.flush()
+            self.serial.send(cmd_clrhighs(period))
+            ok = self._read_status_reply()
+            logger.info(
+                "CLRHIGHS %d (%s highs): %s",
+                period, name, "cleared" if ok else "unexpected response",
+            )
+            return ok
+
+    def clear_lows(self, period: int = CLR_PERIOD_DAILY) -> bool:
+        """CLRLOWS — clear ALL low records for a period.  **IRREVERSIBLE.**
+
+        Same period argument and same all-or-nothing caveat as
+        clear_highs(); see that docstring.
+        """
+        if period not in CLR_PERIODS:
+            raise ValueError(
+                f"CLRLOWS period must be one of {sorted(CLR_PERIODS)} "
+                f"(got {period})"
+            )
+        name = CLR_PERIOD_NAMES.get(period, str(period))
+        with self._io_lock:
+            self._wakeup()
+            self.serial.flush()
+            self.serial.send(cmd_clrlows(period))
+            ok = self._read_status_reply()
+            logger.info(
+                "CLRLOWS %d (%s lows): %s",
+                period, name, "cleared" if ok else "unexpected response",
+            )
+            return ok
+
     async def async_clear_variable(self, variable: int) -> bool:
         return await self._run_in_executor(self.clear_variable, variable)
+
+    async def async_clear_highs(self, period: int = CLR_PERIOD_DAILY) -> bool:
+        return await self._run_in_executor(self.clear_highs, period)
+
+    async def async_clear_lows(self, period: int = CLR_PERIOD_DAILY) -> bool:
+        return await self._run_in_executor(self.clear_lows, period)
 
     async def async_clear_rain_daily(self) -> bool:
         return await self._run_in_executor(self.clear_rain_daily)

--- a/tests/backend/test_vantage_clrhighs.py
+++ b/tests/backend/test_vantage_clrhighs.py
@@ -1,0 +1,115 @@
+"""Tests for CLRHIGHS / CLRLOWS on Vantage stations (Ref #221).
+
+Two things are being pinned down here.
+
+First, the period argument. The manual (§IX.13) says 0/1/2 for
+daily/monthly/yearly, but the docstring in this repo previously claimed
+-1 meant yearly. Nothing called it, so nothing broke — but an unguarded
+call would have put an undefined value on the wire. The validation tests
+below exist so that claim cannot quietly come back.
+
+Second, the blast radius. Per §II.4 there is no way to clear a single
+sensor's extremum: CLRHIGHS 0 drops every daily high the console holds.
+That is a protocol limit, not an implementation gap, so the tests assert
+the command is built exactly as documented rather than pretending a
+narrower version exists.
+"""
+
+import pytest
+
+from app.protocol.vantage.commands import (
+    CLR_PERIODS,
+    CLR_PERIOD_DAILY,
+    CLR_PERIOD_MONTHLY,
+    CLR_PERIOD_NAMES,
+    CLR_PERIOD_YEARLY,
+    cmd_clrhighs,
+    cmd_clrlows,
+)
+from app.protocol.vantage.driver import VantageDriver
+
+
+class TestPeriodConstants:
+    """Values come straight from the manual's own wording:
+    'Clears all of the daily (0), monthly (1), or yearly (2) ...'"""
+
+    @pytest.mark.parametrize("const,expected", [
+        (CLR_PERIOD_DAILY, 0),
+        (CLR_PERIOD_MONTHLY, 1),
+        (CLR_PERIOD_YEARLY, 2),
+    ])
+    def test_period_numbers_match_the_manual(self, const, expected):
+        assert const == expected
+
+    def test_minus_one_is_not_a_period(self):
+        """The old docstring claimed -1 was yearly. It never was."""
+        assert -1 not in CLR_PERIODS
+
+    def test_period_set_is_exactly_zero_one_two(self):
+        assert CLR_PERIODS == frozenset({0, 1, 2})
+
+    def test_every_period_has_a_display_name(self):
+        assert set(CLR_PERIOD_NAMES) == set(CLR_PERIODS)
+
+
+class TestCommandFormat:
+    @pytest.mark.parametrize("period,expected", [
+        (0, b"CLRHIGHS 0\n"),
+        (1, b"CLRHIGHS 1\n"),
+        (2, b"CLRHIGHS 2\n"),
+    ])
+    def test_clrhighs_wire_format(self, period, expected):
+        assert cmd_clrhighs(period) == expected
+
+    @pytest.mark.parametrize("period,expected", [
+        (0, b"CLRLOWS 0\n"),
+        (1, b"CLRLOWS 1\n"),
+        (2, b"CLRLOWS 2\n"),
+    ])
+    def test_clrlows_wire_format(self, period, expected):
+        assert cmd_clrlows(period) == expected
+
+    def test_default_period_is_daily(self):
+        assert cmd_clrhighs() == b"CLRHIGHS 0\n"
+        assert cmd_clrlows() == b"CLRLOWS 0\n"
+
+
+class TestValidation:
+    """Illegal periods must be rejected before any byte reaches the port —
+    the console's behaviour for out-of-range values is undocumented."""
+
+    @pytest.mark.parametrize("bad", [-1, 3, 4, 99, -2])
+    def test_clear_highs_rejects_illegal_period(self, bad):
+        drv = VantageDriver("/dev/null", 19200)
+        with pytest.raises(ValueError, match="CLRHIGHS period"):
+            drv.clear_highs(bad)
+
+    @pytest.mark.parametrize("bad", [-1, 3, 4, 99, -2])
+    def test_clear_lows_rejects_illegal_period(self, bad):
+        drv = VantageDriver("/dev/null", 19200)
+        with pytest.raises(ValueError, match="CLRLOWS period"):
+            drv.clear_lows(bad)
+
+    def test_rejection_names_the_legal_set(self):
+        """The error should tell the caller what IS allowed, not just that
+        they were wrong."""
+        drv = VantageDriver("/dev/null", 19200)
+        with pytest.raises(ValueError, match=r"\[0, 1, 2\]"):
+            drv.clear_highs(-1)
+
+
+class TestDriverInterface:
+    def test_driver_exposes_sync_and_async_variants(self):
+        for name in ("clear_highs", "clear_lows",
+                     "async_clear_highs", "async_clear_lows"):
+            assert hasattr(VantageDriver, name), f"missing {name}"
+
+    def test_clear_methods_default_to_daily(self):
+        """A bare clear_highs() must not surprise the caller by wiping the
+        year."""
+        import inspect
+        for meth in (VantageDriver.clear_highs, VantageDriver.clear_lows,
+                     VantageDriver.async_clear_highs,
+                     VantageDriver.async_clear_lows):
+            sig = inspect.signature(meth)
+            assert sig.parameters["period"].default == CLR_PERIOD_DAILY


### PR DESCRIPTION
Stacked on #223 — both touch `driver.py`/`commands.py`, so this is based on `feature/vantage-hilows` rather than `main`. Merge #223 first and this retargets automatically.

## What's here

`clear_highs()` / `clear_lows()` plus async variants. The command builders already existed but nothing called them, which hid a bug.

## The bug

`cmd_clrhighs`'s docstring claimed **`-1` meant yearly**. The manual (§IX.13) says **0/1/2** for daily/monthly/yearly. An unguarded call would have put an undefined value on the wire — the console's behaviour for out-of-range periods isn't documented. Nothing called it, so nothing broke, but it was a live trap.

Now constrained to `CLR_PERIODS` and rejected before any byte reaches the port. Tests pin `-1 not in CLR_PERIODS` specifically so the claim can't quietly return.

## Blast radius is a protocol limit, not a gap

Per §II.4: *"You can not reset individual high or low values."* `CLRHIGHS 0` clears **every** daily high — baro, wind, humidity, inside temp, the lot. There's no per-sensor variant to implement, so the docstrings say so plainly rather than leaving a caller to find out on production hardware.

## Verification

Backend suite: **628 passed** (602 + 26 new). `py_compile` clean.

Hardware, on the Vue (fw 2.12) — clearing a real bad reading. A failed OAT sensor had latched 68.0 °C:

| field | before | after |
|---|---|---|
| outside_temp day hi | 68.0 | **None** |
| baro day hi | 1017.1 | 1012.9 |
| humidity day hi | 83 | **None** |
| wind day hi | 3.1 | 0.0 |
| outside_temp **month** hi | 68.0 | 68.0 *(untouched)* |
| outside_temp **year** hi | 68.0 | 68.0 *(untouched)* |

The month/year rows are the load-bearing part of that table — they confirm the period argument actually scopes the clear rather than wiping everything, which is the failure mode worth catching on a station holding real data.

Subsequently ran `CLRHIGHS 1` and `CLRHIGHS 2` on the same station: month and year highs went 68.0 → 37.1 °C (the real current temperature), confirming both other periods work too.

Ref #221