### PR TITLE
feat(vantage): implement GETEE and RECEIVERS

### DIFF
--- a/backend/app/protocol/vantage/commands.py
+++ b/backend/app/protocol/vantage/commands.py
@@ -52,6 +52,21 @@ def cmd_bardata() -> bytes:
     return b"BARDATA\n"
 
 
+def cmd_receivers() -> bytes:
+    """RECEIVERS — bitmask of transmitter IDs the console is hearing.
+
+    Manual section IX.1.  Replies "OK" then a single RAW byte, not text:
+    bit 0 = Tx ID 1.  Note this reports what is being *received*, not what
+    the console is configured to listen for (EEPROM USETX at 0x18).
+    """
+    return b"RECEIVERS\n"
+
+
+def cmd_getee() -> bytes:
+    """GETEE — dump the entire 4096-byte EEPROM plus a 2-byte CRC (§IX.4)."""
+    return b"GETEE\n"
+
+
 def cmd_dmpaft() -> bytes:
     """DMPAFT — begin archive dump after timestamp."""
     return b"DMPAFT\n"

--- a/backend/app/protocol/vantage/constants.py
+++ b/backend/app/protocol/vantage/constants.py
@@ -44,6 +44,15 @@ ARCHIVE_RECORDS_PER_PAGE = 5
 # page 0.
 DMPAFT_HEADER_SIZE = 6
 
+# --------------- GETEE ---------------
+
+# Full EEPROM dump: 4096 bytes of data plus a trailing 2-byte CRC.
+# Measured on a Vue at 19200 8N1: 4098 bytes arrive in ~2.14 s, which is
+# the theoretical wire time, so a single receive() call is sufficient and
+# no chunking is needed.
+EEPROM_SIZE = 4096
+GETEE_TOTAL_SIZE = 4098
+
 # --------------- Calibration ---------------
 
 # CALED / CALFIX exchange a 43-byte block (section X.6):

--- a/backend/app/protocol/vantage/driver.py
+++ b/backend/app/protocol/vantage/driver.py
@@ -48,6 +48,8 @@ from .constants import (
     RAIN_CLICK_INCHES,
     ARCHIVE_PAGE_SIZE,
     DMPAFT_HEADER_SIZE,
+    EEPROM_SIZE,
+    GETEE_TOTAL_SIZE,
     STATION_TYPE_WRD_ADDR,
     CALFIX_BLOCK_SIZE,
     CALFIX_OFF_INSIDE_TEMP,
@@ -70,6 +72,8 @@ from .commands import (
     cmd_nver,
     cmd_rxcheck,
     cmd_bardata,
+    cmd_receivers,
+    cmd_getee,
     cmd_dmpaft,
     cmd_gettime,
     cmd_settime,
@@ -1188,6 +1192,88 @@ class VantageDriver(StationDriver):
                 block, rain_click_inches=self.hw_config.rain_click_inches,
             )
 
+    # ---- RECEIVERS: transmitter IDs being heard ----
+
+    def receivers(self) -> Optional[list[int]]:
+        """Which transmitter IDs the console is currently hearing (§IX.1).
+
+        Returns a sorted list of Tx IDs (1-8), or None if the console did
+        not answer.  An EMPTY LIST IS A VALID ANSWER, not a failure.
+
+        On a Vantage Vue this legitimately returns [] — and that is worth
+        stating plainly, because it looks alarming next to a station that
+        is clearly working.  The Vue's sensor suite is integrated rather
+        than paired as an addressable transmitter, so the whole Tx-ID
+        mechanism (a Vantage Pro2 concept for external transmitters) has
+        nothing to report.  Measured on a Vue (fw 2.12): RECEIVERS returns
+        0x00 and EEPROM USETX is 0x00, while RXCHECK simultaneously shows
+        23,516 packets received and LOOP returns live sensor data.
+
+        Note this is what the console *hears*, which is not the same as
+        what it is configured to listen for (EEPROM USETX, 0x18).
+        """
+        with self._io_lock:
+            self._wakeup()
+            self.serial.flush()
+            self.serial.send(cmd_receivers())
+            # "OK" then one RAW byte — not text, so the usual text reader
+            # would mangle a 0x01 into something unprintable.
+            raw = self.serial.receive(16)
+
+        idx = raw.find(b"OK")
+        if idx < 0:
+            logger.warning("RECEIVERS: no OK in response: %r", raw)
+            return None
+        payload = raw[idx + 2:].lstrip(b"\n\r")
+        if not payload:
+            logger.warning("RECEIVERS: no bitmask byte after OK: %r", raw)
+            return None
+
+        bitmask = payload[0]
+        heard = [n + 1 for n in range(8) if bitmask & (1 << n)]
+        logger.info(
+            "RECEIVERS: bitmask 0x%02X — hearing %s",
+            bitmask, heard if heard else "no addressable transmitters",
+        )
+        return heard
+
+    # ---- GETEE: full EEPROM dump ----
+
+    def get_eeprom(self) -> Optional[bytes]:
+        """Dump the whole 4096-byte EEPROM via GETEE (§IX.4).
+
+        Returns the 4096 data bytes with the trailing CRC stripped, or
+        None on a short read or CRC failure.
+
+        This is the largest single transfer in the protocol.  At 19200
+        8N1, 4098 bytes is ~2.1 s of wire time and a Vue delivers it in
+        one receive() — measured at 2.14 s — so no chunking is required.
+        """
+        with self._io_lock:
+            self._wakeup()
+            self.serial.flush()
+            self.serial.send(cmd_getee())
+
+            ack = self.serial.receive_byte()
+            if ack != ACK:
+                raise ConnectionError("GETEE: no ACK")
+
+            block = self.serial.receive(GETEE_TOTAL_SIZE)
+
+        if len(block) < GETEE_TOTAL_SIZE:
+            logger.warning(
+                "GETEE: short read (%d of %d bytes)",
+                len(block), GETEE_TOTAL_SIZE,
+            )
+            return None
+
+        if not crc_validate(block[:GETEE_TOTAL_SIZE]):
+            logger.warning("GETEE: CRC failed")
+            return None
+
+        logger.info("GETEE: read %d bytes of EEPROM", EEPROM_SIZE)
+        return block[:EEPROM_SIZE]
+
     # ---- Text response reader ----
 
     def _read_status_reply(self, timeout_reads: int = 24) -> bool:
@@ -1308,3 +1394,9 @@ class VantageDriver(StationDriver):
 
     async def async_bardata(self) -> Optional[BarometerCalibration]:
         return await self._run_in_executor(self.bardata)
+
+    async def async_receivers(self) -> Optional[list[int]]:
+        return await self._run_in_executor(self.receivers)
+
+    async def async_get_eeprom(self) -> Optional[bytes]:
+        return await self._run_in_executor(self.get_eeprom)

--- a/tests/backend/test_vantage_getee_receivers.py
+++ b/tests/backend/test_vantage_getee_receivers.py
@@ -1,0 +1,162 @@
+"""Tests for GETEE and RECEIVERS on Vantage stations (Ref #221).
+
+The load-bearing case here is RECEIVERS returning an empty result.
+
+On a Vantage Vue it genuinely reports 0x00 — no transmitters heard — while
+the station is working perfectly: measured on fw 2.12, RECEIVERS gave 0x00
+and EEPROM USETX gave 0x00 at the same moment RXCHECK reported 23,516
+packets received and LOOP returned live sensor data. The Vue's suite is
+integrated rather than paired as an addressable transmitter, so the Tx-ID
+mechanism (a Vantage Pro2 concept) has nothing to report.
+
+That makes [] a *correct answer*, and the tests below pin the distinction
+between "no transmitters" and "no response" so a future change cannot
+quietly turn a working Vue into an error state.
+"""
+
+import struct
+
+import pytest
+
+from app.protocol.crc import crc_calculate
+from app.protocol.vantage.commands import cmd_getee, cmd_receivers
+from app.protocol.vantage.constants import EEPROM_SIZE, GETEE_TOTAL_SIZE
+from app.protocol.vantage.driver import VantageDriver
+
+
+class TestCommandFormat:
+    def test_receivers_command(self):
+        assert cmd_receivers() == b"RECEIVERS\n"
+
+    def test_getee_command(self):
+        assert cmd_getee() == b"GETEE\n"
+
+
+class TestSizeConstants:
+    def test_eeprom_is_4k(self):
+        assert EEPROM_SIZE == 4096
+
+    def test_total_includes_crc(self):
+        assert GETEE_TOTAL_SIZE == EEPROM_SIZE + 2
+
+
+class _FakeSerial:
+    """Minimal SerialPort stand-in that replays a scripted response."""
+
+    def __init__(self, response: bytes, ack: int | None = None):
+        self._response = response
+        self._ack = ack
+        self.is_open = True
+
+    def flush(self):
+        pass
+
+    def send(self, data):
+        pass
+
+    def receive(self, n):
+        out, self._response = self._response[:n], self._response[n:]
+        return out
+
+    def receive_byte(self):
+        return self._ack
+
+
+def _driver_with(response: bytes, ack: int | None = None) -> VantageDriver:
+    drv = VantageDriver("/dev/null", 19200)
+    drv.serial = _FakeSerial(response, ack)
+    drv._wakeup = lambda: None      # bypass the console handshake
+    return drv
+
+
+class TestReceiversBitmask:
+    """Bit N corresponds to Tx ID N+1 (manual §IX.1)."""
+
+    @pytest.mark.parametrize("bitmask,expected", [
+        (0x00, []),
+        (0x01, [1]),
+        (0x02, [2]),
+        (0x03, [1, 2]),
+        (0x05, [1, 3]),
+        (0x80, [8]),
+        (0xFF, [1, 2, 3, 4, 5, 6, 7, 8]),
+    ])
+    def test_bitmask_decodes_to_transmitter_ids(self, bitmask, expected):
+        drv = _driver_with(b"\n\rOK\n\r" + bytes([bitmask]))
+        assert drv.receivers() == expected
+
+    def test_empty_is_a_valid_answer_not_a_failure(self):
+        """A Vue reports 0x00 while working normally. [] must come back as
+        a real result, distinguishable from None."""
+        drv = _driver_with(b"\n\rOK\n\r\x00")
+        result = drv.receivers()
+        assert result == []
+        assert result is not None
+
+    def test_no_ok_in_response_is_none(self):
+        drv = _driver_with(b"\n\rgarbage\n\r")
+        assert drv.receivers() is None
+
+    def test_missing_payload_byte_is_none(self):
+        """OK arrived but the bitmask did not — that IS a failure, and must
+        not be confused with a legitimate 0x00."""
+        drv = _driver_with(b"\n\rOK\n\r")
+        assert drv.receivers() is None
+
+    def test_empty_result_distinguishable_from_no_response(self):
+        """The whole point: these two cases must not collapse together."""
+        working_vue = _driver_with(b"\n\rOK\n\r\x00")
+        no_answer = _driver_with(b"")
+        assert working_vue.receivers() == []
+        assert no_answer.receivers() is None
+
+
+class TestGetEeprom:
+    def _valid_block(self, payload: bytes | None = None) -> bytes:
+        data = payload if payload is not None else bytes(
+            range(256)) * (EEPROM_SIZE // 256)
+        assert len(data) == EEPROM_SIZE
+        crc = crc_calculate(data)
+        return data + struct.pack(">H", crc)
+
+    def test_returns_4096_bytes_with_crc_stripped(self):
+        drv = _driver_with(self._valid_block(), ack=0x06)
+        result = drv.get_eeprom()
+        assert result is not None
+        assert len(result) == EEPROM_SIZE
+
+    def test_payload_round_trips(self):
+        payload = bytes((i * 7) % 256 for i in range(EEPROM_SIZE))
+        drv = _driver_with(self._valid_block(payload), ack=0x06)
+        assert drv.get_eeprom() == payload
+
+    def test_short_read_returns_none(self):
+        drv = _driver_with(b"\x00" * 100, ack=0x06)
+        assert drv.get_eeprom() is None
+
+    def test_bad_crc_returns_none(self):
+        data = bytes(EEPROM_SIZE)
+        drv = _driver_with(data + b"\xDE\xAD", ack=0x06)
+        assert drv.get_eeprom() is None
+
+    def test_no_ack_raises(self):
+        drv = _driver_with(self._valid_block(), ack=0x21)   # NAK
+        with pytest.raises(ConnectionError, match="GETEE: no ACK"):
+            drv.get_eeprom()
+
+    def test_known_offsets_readable_from_dump(self):
+        """A dump is only useful if documented addresses land where the
+        EEPROM map says. 0x0F is elevation in feet."""
+        data = bytearray(EEPROM_SIZE)
+        struct.pack_into("<h", data, 0x0F, 265)
+        drv = _driver_with(self._valid_block(bytes(data)), ack=0x06)
+        dump = drv.get_eeprom()
+        assert struct.unpack_from("<h", dump, 0x0F)[0] == 265
+
+
+class TestDriverInterface:
+    @pytest.mark.parametrize("name", [
+        "receivers", "async_receivers", "get_eeprom", "async_get_eeprom",
+    ])
+    def test_driver_exposes(self, name):
+        assert hasattr(VantageDriver, name), f"missing {name}"


### PR DESCRIPTION
Stacked on #226 → #225 → #224 → #223. Merge in order; each retargets automatically.

Two read-only commands from the #221 audit.

## GETEE

Dumps all 4096 EEPROM bytes plus a CRC — the largest single transfer in this protocol. At 19200 8N1 that's ~2.1 s of wire time, and a Vue delivers it in one `receive()` (measured 2.14 s), so no chunking needed. Returns the data with CRC stripped, or `None` on short read / CRC failure.

## RECEIVERS

Reports which transmitter IDs the console is hearing, as a **raw bitmask byte** after the `OK` — not text, so the usual text reader would mangle it.

### On a Vue this legitimately returns nothing

This is the part worth reading carefully, because `[]` looks like a bug next to a station that's obviously working.

Measured on fw 2.12, simultaneously:

| | |
|---|---|
| RECEIVERS | `0x00` |
| EEPROM USETX (0x18) | `0x00` |
| RXCHECK | **23,516 packets received**, 99 missed |
| LOOP | live sensor data, 37.7 °C |

The Vue's sensor suite is **integrated**, not paired as an addressable transmitter. The whole Tx-ID mechanism is a Vantage Pro2 concept for external transmitters, so on a Vue it has nothing to report while the built-in sensors work normally.

So `[]` is a **correct answer, not a fault**. `receivers()` returns it as a real result distinguishable from `None`, and a test pins that distinction specifically — collapsing the two would turn a healthy Vue into a permanent error state. The code comment explains why rather than leaving the next reader to re-derive it from an alarming-looking `0x00`.

## Verification

**696 tests pass** (671 + 25). `py_compile` clean.

Through the driver on hardware:

```
RECEIVERS -> []  (real result, not None)

GETEE -> 4096 bytes in 2.25s, CRC validated
  0x0B latitude  = 380 (38.0 deg)
  0x0D longitude = -780 (-78.0 deg)
  0x0F elevation = 265 ft
  0x18 USETX     = 0x00

PASS: elevation agrees with BARDATA (265 ft)
PASS: EEBRD 0x0F agrees with the GETEE dump
```

Those last two are the useful ones — they confirm the dump is *aligned*, not merely internally consistent, by cross-checking one documented address against two independent read paths.

## Incidental finding

The EEPROM has lat/lon as **38.0 / -78.0**, but the station is at 35.38 / -78.60 — roughly 180 miles off. Stale config from a previous location, unrelated to this PR, but worth knowing since it feeds the console's own sunrise/sunset and pressure-correction maths. Not touching it here.

Ref #221