### PR TITLE
feat(vantage): implement PUTRAIN, PUTET and DMP

### DIFF
--- a/backend/app/protocol/vantage/commands.py
+++ b/backend/app/protocol/vantage/commands.py
@@ -67,6 +67,42 @@ def cmd_getee() -> bytes:
     return b"GETEE\n"
 
 
+def cmd_putrain(clicks: int) -> bytes:
+    """PUTRAIN — set the yearly rain total, in RAIN CLICKS (§IX.2).
+
+    The unit is clicks, not inches and not millimetres, and a click is not
+    a fixed size: 0.01", 0.2 mm or 0.1 mm depending on the collector
+    fitted (EEPROM setup bits, 0x2B).  Passing a value in any other unit
+    silently sets the wrong yearly total, so callers should go through
+    VantageDriver.set_yearly_rain(), which converts from mm using the
+    collector this station actually reports.
+
+    The manual's example sets 24.83 inches on a 0.01" collector as
+    "PUTRAIN 2483".
+    """
+    return f"PUTRAIN {clicks}\n".encode()
+
+
+def cmd_putet(hundredths_inch: int) -> bytes:
+    """PUTET — set the yearly ET total, in HUNDREDTHS OF AN INCH (§IX.2).
+
+    Note this differs from PUTRAIN: ET is a fixed hundredths-of-an-inch
+    unit with no collector dependency.  The two commands sit next to each
+    other in the manual and read alike, which makes it easy to assume they
+    share a unit.  They do not.
+    """
+    return f"PUTET {hundredths_inch}\n".encode()
+
+
+def cmd_dmp() -> bytes:
+    """DMP — download the entire archive memory (§IX.3).
+
+    Uses the same paged transfer as DMPAFT (§X.6): 267-byte pages, each
+    ACKed or NAKed, ESC to abort.
+    """
+    return b"DMP\n"
+
+
 def cmd_dmpaft() -> bytes:
     """DMPAFT — begin archive dump after timestamp."""
     return b"DMPAFT\n"

--- a/backend/app/protocol/vantage/constants.py
+++ b/backend/app/protocol/vantage/constants.py
@@ -39,6 +39,13 @@ ARCHIVE_PAGE_HEADER_SIZE = 1     # leading sequence byte, before record 0
 ARCHIVE_RECORD_SIZE = 52
 ARCHIVE_RECORDS_PER_PAGE = 5
 
+# DMP streams the whole archive with no page-count header (unlike DMPAFT,
+# which negotiates one), so the reader needs the fixed size: the console
+# holds 2560 records = 512 pages of 5.  §I quotes "up to 2560 archive
+# records" for a console with a WeatherLink logger fitted.
+ARCHIVE_TOTAL_RECORDS = 2560
+ARCHIVE_TOTAL_PAGES = ARCHIVE_TOTAL_RECORDS // ARCHIVE_RECORDS_PER_PAGE
+
 # DMPAFT response header: page_count (u16 LE) + first_record_offset (u16 LE)
 # + CRC (u16 BE).  The station waits for an ACK after this before sending
 # page 0.

--- a/backend/app/protocol/vantage/driver.py
+++ b/backend/app/protocol/vantage/driver.py
@@ -47,6 +47,7 @@ from .constants import (
     LOOP2_PACKET_SIZE,
     RAIN_CLICK_INCHES,
     ARCHIVE_PAGE_SIZE,
+    ARCHIVE_TOTAL_PAGES,
     DMPAFT_HEADER_SIZE,
     EEPROM_SIZE,
     GETEE_TOTAL_SIZE,
@@ -74,6 +75,9 @@ from .commands import (
     cmd_bardata,
     cmd_receivers,
     cmd_getee,
+    cmd_putrain,
+    cmd_putet,
+    cmd_dmp,
     cmd_dmpaft,
     cmd_gettime,
     cmd_settime,
@@ -967,6 +971,136 @@ class VantageDriver(StationDriver):
 
     # ---- Archive (DMPAFT) ----
 
+    def _read_archive_pages(
+        self,
+        page_count: int,
+        first_offset: int,
+        label: str,
+        after: Optional[datetime] = None,
+    ) -> list[VantageArchiveRecord]:
+        """Read `page_count` archive pages off the wire and parse them.
+
+        Shared by DMP and DMPAFT — the paged transfer in §X.6 is identical
+        for both, and this logic carries two hard-won details worth having
+        in exactly one place: a NAK asks the station to resend the SAME
+        page (so the loop counter must not advance on failure), and an ESC
+        is required to abort cleanly rather than leaving the station mid
+        stream.
+
+        `after` filters records by timestamp; DMP passes None to keep
+        everything.  Caller must already hold _io_lock and have consumed
+        the response header.
+        """
+        records: list[VantageArchiveRecord] = []
+        pages_read = 0
+
+        for page_num in range(page_count):
+            page_data = None
+
+            for attempt in range(MAX_RETRIES):
+                if self._stop_requested:
+                    self.serial.send(bytes([ESC]))
+                    logger.info(
+                        "%s: aborted by stop request at page %d",
+                        label, page_num,
+                    )
+                    page_data = None
+                    break
+
+                chunk = self.serial.receive(ARCHIVE_PAGE_SIZE)
+                if len(chunk) < ARCHIVE_PAGE_SIZE:
+                    logger.warning(
+                        "%s page %d: short read (%d of %d bytes), attempt %d/%d",
+                        label, page_num, len(chunk), ARCHIVE_PAGE_SIZE,
+                        attempt + 1, MAX_RETRIES,
+                    )
+                    self.serial.send(bytes([NAK]))
+                    continue
+
+                if not crc_validate(chunk):
+                    logger.warning(
+                        "%s page %d: CRC failed, attempt %d/%d",
+                        label, page_num, attempt + 1, MAX_RETRIES,
+                    )
+                    self.serial.send(bytes([NAK]))
+                    continue
+
+                page_data = chunk
+                break
+
+            if self._stop_requested:
+                break
+
+            if page_data is None:
+                self.serial.send(bytes([ESC]))
+                raise ConnectionError(
+                    f"{label}: page {page_num} unreadable after "
+                    f"{MAX_RETRIES} attempts"
+                )
+
+            self.serial.send(bytes([ACK]))
+            pages_read += 1
+
+            for offset, record_bytes in parse_archive_page(page_data):
+                if page_num == 0 and offset < first_offset:
+                    continue
+
+                record = parse_archive_record(
+                    record_bytes, self.hw_config.rain_click_inches,
+                )
+                if record is None:
+                    continue
+
+                # Whole pages are sent, so the last one is padded with
+                # unwritten slots.  Drop anything without a timestamp, and
+                # when filtering, anything at or before the cutoff.
+                if record.timestamp is None:
+                    continue
+                if after is not None and record.timestamp <= after:
+                    continue
+
+                records.append(record)
+
+        logger.info(
+            "%s: retrieved %d records from %d/%d pages",
+            label, len(records), pages_read, page_count,
+        )
+        return records
+
+    def dmp(self) -> list[VantageArchiveRecord]:
+        """DMP — download the ENTIRE archive memory (§IX.3).
+
+        Where DMPAFT asks for records after a timestamp, this pulls
+        everything the console holds: up to 2560 records across 512 pages.
+        At 19200 baud that is several minutes of transfer, and it is
+        interruptible via request_stop().
+
+        Read-only — it does not alter or clear the archive.  Prefer
+        dmpaft() for routine syncing; this is for a full re-read, e.g.
+        rebuilding a database from the console.
+        """
+        with self._io_lock:
+            self._wakeup()
+            self.serial.flush()
+            self.serial.send(cmd_dmp())
+
+            ack = self.serial.receive_byte()
+            if ack != ACK:
+                raise ConnectionError("DMP: no ACK")
+
+            # DMP streams pages immediately with no page-count header —
+            # unlike DMPAFT, which negotiates one.  The archive is a fixed
+            # 512 pages of 5 records.
+            return self._read_archive_pages(
+                page_count=ARCHIVE_TOTAL_PAGES,
+                first_offset=0,
+                label="DMP",
+                after=None,
+            )
+
+    async def async_dmp(self) -> list[VantageArchiveRecord]:
+        return await self._run_in_executor(self.dmp)
+
     def dmpaft(self, after: datetime) -> list[VantageArchiveRecord]:
         """Download archive records after the given timestamp."""
         with self._io_lock:
@@ -1016,87 +1150,12 @@ class VantageDriver(StationDriver):
             # subsequent one returns zero bytes.
             self.serial.send(bytes([ACK]))
 
-            records: list[VantageArchiveRecord] = []
-            pages_read = 0
-            for page_num in range(page_count):
-                page_data = None
-
-                # Retry a corrupt or short page in place.  NAK asks the
-                # station to resend the SAME page, so advancing the loop
-                # counter on failure (as this previously did) desynchronises
-                # the stream from the station.
-                for attempt in range(MAX_RETRIES):
-                    if self._stop_requested:
-                        self.serial.send(bytes([ESC]))
-                        logger.info("DMPAFT: aborted by stop request at page %d", page_num)
-                        page_data = None
-                        break
-
-                    chunk = self.serial.receive(ARCHIVE_PAGE_SIZE)
-                    if len(chunk) < ARCHIVE_PAGE_SIZE:
-                        logger.warning(
-                            "DMPAFT page %d: short read (%d of %d bytes), attempt %d/%d",
-                            page_num, len(chunk), ARCHIVE_PAGE_SIZE,
-                            attempt + 1, MAX_RETRIES,
-                        )
-                        self.serial.send(bytes([NAK]))
-                        continue
-
-                    if not crc_validate(chunk):
-                        logger.warning(
-                            "DMPAFT page %d: CRC failed, attempt %d/%d",
-                            page_num, attempt + 1, MAX_RETRIES,
-                        )
-                        self.serial.send(bytes([NAK]))
-                        continue
-
-                    page_data = chunk
-                    break
-
-                if self._stop_requested:
-                    break
-
-                if page_data is None:
-                    # Out of retries — abort rather than press on against a
-                    # stream we can no longer trust.
-                    self.serial.send(bytes([ESC]))
-                    raise ConnectionError(
-                        f"DMPAFT: page {page_num} unreadable after "
-                        f"{MAX_RETRIES} attempts"
-                    )
-
-                # ACK advances the station to the next page.
-                self.serial.send(bytes([ACK]))
-                pages_read += 1
-
-                # Parse records
-                page_records = parse_archive_page(page_data)
-                for offset, record_bytes in page_records:
-                    if page_num == 0 and offset < first_offset:
-                        continue  # skip records before the requested time
-
-                    record = parse_archive_record(
-                        record_bytes, self.hw_config.rain_click_inches,
-                    )
-                    if record is None:
-                        continue
-
-                    # The station sends whole pages, so the final page is
-                    # padded with unwritten slots and any page may carry
-                    # records older than the request.  first_offset only
-                    # covers page 0, so filter on the timestamp too --
-                    # otherwise a request for a future time still returns
-                    # the tail of the archive.
-                    if record.timestamp is None or record.timestamp <= after:
-                        continue
-
-                    records.append(record)
-
-            logger.info(
-                "DMPAFT: retrieved %d records from %d/%d pages",
-                len(records), pages_read, page_count,
+            return self._read_archive_pages(
+                page_count=page_count,
+                first_offset=first_offset,
+                label="DMPAFT",
+                after=after,
             )
-            return records
 
     # ---- RXCHECK diagnostics ----
 
@@ -1274,7 +1333,83 @@ class VantageDriver(StationDriver):
         logger.info("GETEE: read %d bytes of EEPROM", EEPROM_SIZE)
         return block[:EEPROM_SIZE]
 
-    # ---- Text response reader ----
+    # ---- Station location ----
+
+    def set_yearly_rain(self, millimetres: float) -> bool:
+        """PUTRAIN — overwrite the console's yearly rain total.  **IRREVERSIBLE.**
+
+        Takes millimetres, matching how this codebase reports rain
+        everywhere else, and converts to clicks using the collector this
+        station actually reported at connect time.
+
+        That conversion is the whole point of this wrapper.  PUTRAIN's
+        native unit is rain clicks, and a click is 0.01", 0.2 mm or 0.1 mm
+        depending on the collector fitted — so the same integer means
+        three different rainfall totals on three different stations.
+        Sending a raw click count without knowing the collector is how you
+        silently set a yearly total that is off by a factor of two.
+
+        There is no read-back-and-restore here: the previous total is gone
+        once this succeeds.  Read the current value from a LOOP packet
+        first if it might be wanted.
+        """
+        if millimetres < 0:
+            raise ValueError(f"rain total cannot be negative: {millimetres}")
+
+        click_inches = self.hw_config.rain_click_inches
+        if not click_inches:
+            logger.warning(
+                "set_yearly_rain: rain collector size unknown; refusing to "
+                "guess (would risk a 2x error in the stored total)"
+            )
+            return False
+
+        clicks = int(round(millimetres / (click_inches * 25.4)))
+
+        with self._io_lock:
+            self._wakeup()
+            self.serial.flush()
+            self.serial.send(cmd_putrain(clicks))
+            ok = self._read_status_reply()
+
+        logger.info(
+            "PUTRAIN %d clicks (%.2f mm at %.4f\"/click): %s",
+            clicks, millimetres, click_inches,
+            "set" if ok else "unexpected response",
+        )
+        return ok
+
+    def set_yearly_et(self, millimetres: float) -> bool:
+        """PUTET — overwrite the console's yearly ET total.  **IRREVERSIBLE.**
+
+        Takes millimetres for consistency with set_yearly_rain(), but note
+        the wire unit differs: ET is hundredths of an inch, fixed, with no
+        collector dependency.  PUTRAIN and PUTET sit adjacent in the manual
+        and read alike, which makes assuming a shared unit an easy mistake.
+        """
+        if millimetres < 0:
+            raise ValueError(f"ET total cannot be negative: {millimetres}")
+
+        hundredths = int(round(millimetres / 25.4 * 100))
+
+        with self._io_lock:
+            self._wakeup()
+            self.serial.flush()
+            self.serial.send(cmd_putet(hundredths))
+            ok = self._read_status_reply()
+
+        logger.info(
+            "PUTET %d hundredths-inch (%.2f mm): %s",
+            hundredths, millimetres, "set" if ok else "unexpected response",
+        )
+        return ok
+
+    async def async_set_yearly_rain(self, millimetres: float) -> bool:
+        return await self._run_in_executor(self.set_yearly_rain, millimetres)
+
+    async def async_set_yearly_et(self, millimetres: float) -> bool:
+        return await self._run_in_executor(self.set_yearly_et, millimetres)
+
 
     def _read_status_reply(self, timeout_reads: int = 24) -> bool:
         """Read a bare success reply from a command that returns no payload.
@@ -1400,3 +1535,4 @@ class VantageDriver(StationDriver):
 
     async def async_get_eeprom(self) -> Optional[bytes]:
         return await self._run_in_executor(self.get_eeprom)
+

--- a/tests/backend/test_vantage_dmp.py
+++ b/tests/backend/test_vantage_dmp.py
@@ -1,0 +1,184 @@
+"""Tests for DMP — full archive download (Ref #221).
+
+DMP and DMPAFT share the paged transfer in §X.6, so the page/retry/CRC
+loop is now factored into _read_archive_pages() and both call it. That
+shared code carries two details that were expensive to get right the
+first time, and the tests below pin them so a future edit cannot quietly
+undo either:
+
+  * A NAK asks the station to resend the SAME page. The loop counter must
+    not advance on failure, or the stream desynchronises from the station.
+  * An ESC is required to abort cleanly. Walking away mid-transfer leaves
+    the station still sending.
+
+The difference between the two commands is the header: DMPAFT negotiates
+a page count, DMP just starts streaming, so DMP supplies the fixed
+archive size instead.
+"""
+
+import struct
+
+import pytest
+
+from app.protocol.crc import crc_calculate
+from app.protocol.vantage.commands import cmd_dmp
+from app.protocol.vantage.constants import (
+    ACK,
+    ARCHIVE_PAGE_SIZE,
+    ARCHIVE_RECORDS_PER_PAGE,
+    ARCHIVE_TOTAL_PAGES,
+    ARCHIVE_TOTAL_RECORDS,
+    ESC,
+    NAK,
+)
+from app.protocol.vantage.driver import VantageDriver
+
+
+def test_command_format():
+    assert cmd_dmp() == b"DMP\n"
+
+
+class TestArchiveSizeConstants:
+    def test_total_records_matches_the_manual(self):
+        """§I quotes 'up to 2560 archive records'."""
+        assert ARCHIVE_TOTAL_RECORDS == 2560
+
+    def test_pages_derived_from_records_per_page(self):
+        assert ARCHIVE_TOTAL_PAGES == 512
+        assert ARCHIVE_TOTAL_PAGES * ARCHIVE_RECORDS_PER_PAGE == 2560
+
+
+def _make_page(seq: int, record_time: int = 0) -> bytes:
+    """A structurally valid 267-byte archive page with a good CRC."""
+    page = bytearray(ARCHIVE_PAGE_SIZE)
+    page[0] = seq
+    for i in range(ARCHIVE_RECORDS_PER_PAGE):
+        base = 1 + i * 52
+        # date stamp 0 marks an unwritten slot, which the parser skips —
+        # fine here, since these tests are about transfer mechanics.
+        struct.pack_into("<H", page, base, record_time)
+    crc = crc_calculate(bytes(page[:ARCHIVE_PAGE_SIZE - 2]))
+    struct.pack_into(">H", page, ARCHIVE_PAGE_SIZE - 2, crc)
+    return bytes(page)
+
+
+class _ScriptedSerial:
+    """Replays pages and records every control byte the driver sends."""
+
+    is_open = True
+
+    def __init__(self, pages: list[bytes], ack_first: bool = True):
+        self._queue = list(pages)
+        self._buf = b""
+        self._ack_first = ack_first
+        self.control: list[int] = []
+        self.corrupt_next = 0
+
+    def flush(self):
+        pass
+
+    def send(self, data: bytes):
+        if len(data) == 1 and data[0] in (ACK, NAK, ESC):
+            self.control.append(data[0])
+
+    def receive_byte(self):
+        return ACK if self._ack_first else NAK
+
+    def receive(self, n: int) -> bytes:
+        while len(self._buf) < n and self._queue:
+            page = self._queue.pop(0)
+            if self.corrupt_next > 0:
+                page = page[:-2] + b"\xDE\xAD"   # break the CRC
+                self.corrupt_next -= 1
+            self._buf += page
+        out, self._buf = self._buf[:n], self._buf[n:]
+        return out
+
+
+def _driver(pages, ack_first=True, total_pages=None):
+    drv = VantageDriver("/dev/null", 19200)
+    drv.serial = _ScriptedSerial(pages, ack_first)
+    drv._wakeup = lambda: None
+    if total_pages is not None:
+        import app.protocol.vantage.driver as mod
+        drv._test_pages = total_pages
+    return drv
+
+
+class TestDmpTransfer:
+    def test_no_ack_raises(self):
+        drv = _driver([_make_page(0)], ack_first=False)
+        with pytest.raises(ConnectionError, match="DMP: no ACK"):
+            drv.dmp()
+
+    def test_each_good_page_is_acked(self, monkeypatch):
+        """ACK advances the station; without it the transfer stalls."""
+        monkeypatch.setattr(
+            "app.protocol.vantage.driver.ARCHIVE_TOTAL_PAGES", 3)
+        drv = _driver([_make_page(i) for i in range(3)])
+        drv.dmp()
+        assert drv.serial.control.count(ACK) == 3
+        assert NAK not in drv.serial.control
+
+    def test_corrupt_page_is_naked_then_retried(self, monkeypatch):
+        """A NAK must ask for the SAME page again, not skip ahead."""
+        monkeypatch.setattr(
+            "app.protocol.vantage.driver.ARCHIVE_TOTAL_PAGES", 1)
+        page = _make_page(0)
+        drv = _driver([page, page])          # corrupt copy, then good one
+        drv.serial.corrupt_next = 1
+        drv.dmp()
+        assert NAK in drv.serial.control, "corrupt page should be NAKed"
+        assert ACK in drv.serial.control, "retry should then be ACKed"
+        # NAK must come before the ACK — proving it retried rather than
+        # accepted the bad page and moved on.
+        assert (drv.serial.control.index(NAK)
+                < drv.serial.control.index(ACK))
+
+    def test_unreadable_page_aborts_with_esc(self, monkeypatch):
+        """Out of retries: send ESC rather than abandoning the station
+        mid-stream."""
+        monkeypatch.setattr(
+            "app.protocol.vantage.driver.ARCHIVE_TOTAL_PAGES", 1)
+        page = _make_page(0)
+        drv = _driver([page] * 5)
+        drv.serial.corrupt_next = 5          # every attempt fails
+        with pytest.raises(ConnectionError, match="unreadable after"):
+            drv.dmp()
+        assert ESC in drv.serial.control
+
+    def test_stop_request_aborts_with_esc(self, monkeypatch):
+        monkeypatch.setattr(
+            "app.protocol.vantage.driver.ARCHIVE_TOTAL_PAGES", 3)
+        drv = _driver([_make_page(i) for i in range(3)])
+        drv.request_stop()
+        drv.dmp()
+        assert ESC in drv.serial.control
+
+    def test_returns_a_list(self, monkeypatch):
+        monkeypatch.setattr(
+            "app.protocol.vantage.driver.ARCHIVE_TOTAL_PAGES", 2)
+        drv = _driver([_make_page(i) for i in range(2)])
+        assert isinstance(drv.dmp(), list)
+
+
+class TestSharedWithDmpaft:
+    def test_both_use_the_same_page_reader(self):
+        """One copy of the retry/CRC/abort logic, not two that drift."""
+        import inspect
+        src = inspect.getsource(VantageDriver.dmp)
+        assert "_read_archive_pages" in src
+        src_after = inspect.getsource(VantageDriver.dmpaft)
+        assert "_read_archive_pages" in src_after
+
+    def test_dmp_passes_no_time_filter(self):
+        """DMP keeps everything; DMPAFT filters on the cutoff."""
+        import inspect
+        src = inspect.getsource(VantageDriver.dmp)
+        assert "after=None" in src
+
+
+class TestDriverInterface:
+    @pytest.mark.parametrize("name", ["dmp", "async_dmp", "_read_archive_pages"])
+    def test_exposed(self, name):
+        assert hasattr(VantageDriver, name), f"missing {name}"

--- a/tests/backend/test_vantage_putrain_putet.py
+++ b/tests/backend/test_vantage_putrain_putet.py
@@ -1,0 +1,193 @@
+"""Tests for PUTRAIN and PUTET (Ref #221).
+
+These two commands sit adjacent in the manual, read almost identically,
+and take DIFFERENT UNITS:
+
+    PUTRAIN <yearly rain in RAIN CLICKS>
+    PUTET   <yearly ET in HUNDREDTHS OF AN INCH>
+
+Worse, a rain click is not a fixed size — 0.01", 0.2 mm or 0.1 mm
+depending on the collector fitted (EEPROM setup bits, 0x2B). So the same
+integer means different rainfall totals on different stations, and a
+caller who assumes a shared unit or a fixed click size silently sets a
+yearly total that is wrong by a factor of two or more.
+
+Both driver wrappers therefore take millimetres — the unit this codebase
+uses for rain everywhere else — and convert. The tests below pin the
+conversions against the manual's own worked example and against each
+collector type.
+"""
+
+import pytest
+
+from app.protocol.vantage.commands import cmd_putet, cmd_putrain
+from app.protocol.vantage.constants import RAIN_CLICK_INCHES
+from app.protocol.vantage.driver import VantageDriver
+
+
+class _RecordingDriver(VantageDriver):
+    """Captures what would go on the wire."""
+
+    def __init__(self, click_inches: float = 0.01):
+        super().__init__("/dev/null", 19200)
+        self.sent: list[bytes] = []
+        self.status_ok = True
+        self.hw_config.rain_click_inches = click_inches
+        self._wakeup = lambda: None
+
+        class _S:
+            is_open = True
+
+            def flush(_s):
+                pass
+
+            def send(_s, data):
+                self.sent.append(data)
+
+            def receive(_s, n):
+                return b""
+
+            def receive_byte(_s):
+                return None
+
+        self.serial = _S()
+
+    def _read_status_reply(self, timeout_reads=24):
+        return self.status_ok
+
+
+class TestCommandFormat:
+    def test_putrain_wire_format(self):
+        assert cmd_putrain(2483) == b"PUTRAIN 2483\n"
+
+    def test_putet_wire_format(self):
+        assert cmd_putet(2483) == b"PUTET 2483\n"
+
+    def test_manual_worked_example(self):
+        """The manual sets 24.83 inches on a 0.01" collector as
+        'PUTRAIN 2483'."""
+        assert cmd_putrain(2483) == b"PUTRAIN 2483\n"
+
+    def test_zero_is_expressible(self):
+        """Setting a yearly total to zero is a legitimate operation —
+        it must not be confused with 'no value'."""
+        assert cmd_putrain(0) == b"PUTRAIN 0\n"
+        assert cmd_putet(0) == b"PUTET 0\n"
+
+
+class TestRainClickConversion:
+    """The load-bearing part: mm -> clicks depends on the collector."""
+
+    def test_imperial_collector(self):
+        """0.01" per click. 24.83 in = 630.68 mm -> 2483 clicks, matching
+        the manual's example."""
+        drv = _RecordingDriver(click_inches=0.01)
+        assert drv.set_yearly_rain(630.68) is True
+        assert drv.sent[-1] == b"PUTRAIN 2483\n"
+
+    def test_metric_02mm_collector(self):
+        """0.2 mm per click: 100 mm -> 500 clicks."""
+        drv = _RecordingDriver(click_inches=RAIN_CLICK_INCHES[1])
+        drv.set_yearly_rain(100.0)
+        assert drv.sent[-1] == b"PUTRAIN 500\n"
+
+    def test_metric_01mm_collector(self):
+        """0.1 mm per click: 100 mm -> 1000 clicks."""
+        drv = _RecordingDriver(click_inches=RAIN_CLICK_INCHES[2])
+        drv.set_yearly_rain(100.0)
+        assert drv.sent[-1] == b"PUTRAIN 1000\n"
+
+    def test_same_mm_gives_different_clicks_per_collector(self):
+        """This is exactly the bug the wrapper exists to prevent: an
+        unconverted click count would be wrong by 2x between these two."""
+        metric_02 = _RecordingDriver(click_inches=RAIN_CLICK_INCHES[1])
+        metric_01 = _RecordingDriver(click_inches=RAIN_CLICK_INCHES[2])
+        metric_02.set_yearly_rain(100.0)
+        metric_01.set_yearly_rain(100.0)
+        assert metric_02.sent[-1] != metric_01.sent[-1]
+
+    def test_refuses_when_collector_unknown(self):
+        """Better to fail than to guess and store a wrong yearly total."""
+        drv = _RecordingDriver()
+        drv.hw_config.rain_click_inches = 0
+        assert drv.set_yearly_rain(100.0) is False
+        assert drv.sent == []
+
+    def test_zero_clears_the_total(self):
+        drv = _RecordingDriver(click_inches=0.01)
+        assert drv.set_yearly_rain(0.0) is True
+        assert drv.sent[-1] == b"PUTRAIN 0\n"
+
+    def test_negative_rejected(self):
+        drv = _RecordingDriver()
+        with pytest.raises(ValueError, match="cannot be negative"):
+            drv.set_yearly_rain(-1.0)
+        assert drv.sent == []
+
+
+class TestEtConversion:
+    """ET is hundredths of an inch, fixed — no collector dependency."""
+
+    def test_hundredths_of_an_inch(self):
+        """24.83 in = 630.68 mm -> 2483 hundredths."""
+        drv = _RecordingDriver()
+        assert drv.set_yearly_et(630.68) is True
+        assert drv.sent[-1] == b"PUTET 2483\n"
+
+    def test_one_inch(self):
+        drv = _RecordingDriver()
+        drv.set_yearly_et(25.4)
+        assert drv.sent[-1] == b"PUTET 100\n"
+
+    def test_et_ignores_collector_size(self):
+        """PUTRAIN's unit depends on the collector; PUTET's does not.
+        Same mm through both collectors must give the same ET command."""
+        a = _RecordingDriver(click_inches=RAIN_CLICK_INCHES[1])
+        b = _RecordingDriver(click_inches=RAIN_CLICK_INCHES[2])
+        a.set_yearly_et(100.0)
+        b.set_yearly_et(100.0)
+        assert a.sent[-1] == b.sent[-1]
+
+    def test_negative_rejected(self):
+        drv = _RecordingDriver()
+        with pytest.raises(ValueError, match="cannot be negative"):
+            drv.set_yearly_et(-1.0)
+        assert drv.sent == []
+
+
+class TestUnitsAreNotShared:
+    """The adjacency trap: same mm must NOT produce the same integer."""
+
+    def test_rain_and_et_differ_for_the_same_millimetres(self):
+        drv = _RecordingDriver(click_inches=RAIN_CLICK_INCHES[1])  # 0.2mm
+        drv.set_yearly_rain(100.0)
+        rain_cmd = drv.sent[-1]
+        drv.set_yearly_et(100.0)
+        et_cmd = drv.sent[-1]
+        rain_n = int(rain_cmd.split()[1])
+        et_n = int(et_cmd.split()[1])
+        assert rain_n != et_n, (
+            "PUTRAIN and PUTET take different units; identical numbers "
+            "for the same millimetres means a conversion was skipped"
+        )
+
+
+class TestFailureReporting:
+    def test_rain_reports_console_refusal(self):
+        drv = _RecordingDriver()
+        drv.status_ok = False
+        assert drv.set_yearly_rain(100.0) is False
+
+    def test_et_reports_console_refusal(self):
+        drv = _RecordingDriver()
+        drv.status_ok = False
+        assert drv.set_yearly_et(100.0) is False
+
+
+class TestDriverInterface:
+    @pytest.mark.parametrize("name", [
+        "set_yearly_rain", "set_yearly_et",
+        "async_set_yearly_rain", "async_set_yearly_et",
+    ])
+    def test_exposed(self, name):
+        assert hasattr(VantageDriver, name), f"missing {name}"


### PR DESCRIPTION
Stacked on #227 → #226 → #225 → #224 → #223. Merge in order; each retargets automatically.

Closes out the remaining commands from the #221 audit.

## DMP

Downloads the entire archive rather than DMPAFT's after-a-timestamp slice. Both use the same paged transfer (§X.6), so the page/retry/CRC loop is now factored into `_read_archive_pages()` and both call it.

That loop carries two details that were expensive to get right and are worth having in exactly one place:
- a **NAK asks the station to resend the SAME page**, so the loop counter must not advance on failure
- an **ESC is required to abort cleanly**, rather than leaving the station mid-stream

The existing DMPAFT tests passing unchanged against the extracted version is the check that the refactor is faithful.

## PUTRAIN / PUTET — the units are a trap

They sit adjacent in the manual, read almost identically, and take **different units**:

```
PUTRAIN <yearly rain in RAIN CLICKS>
PUTET   <yearly ET in HUNDREDTHS OF AN INCH>
```

Worse, **a rain click is not a fixed size** — 0.01", 0.2 mm or 0.1 mm depending on the collector fitted (EEPROM setup bits, 0x2B). The same integer means different rainfall on different stations.

So `set_yearly_rain()` and `set_yearly_et()` both take **millimetres**, matching how this codebase reports rain everywhere else, and convert. `set_yearly_rain()` uses the collector the station actually reported at connect time, and **refuses rather than guessing** if that's unknown. A yearly total off by 2x is the kind of error nobody notices until the season summary looks wrong.

### ⚠️ A coincidence worth not being fooled by

On a **0.01" collector a click and a hundredth-inch are the same size**, so PUTRAIN and PUTET produce *identical* numbers on the bench Vue:

```
100.00 mm -> PUTRAIN 394   | PUTET 394
630.68 mm -> PUTRAIN 2483  | PUTET 2483
```

That is a property of this collector, **not** a shared unit. `test_rain_and_et_differ_for_the_same_millimetres` deliberately uses a metric collector so the distinction is pinned by something other than luck — don't "simplify" the two paths after eyeballing this station.

## Verification

**765 tests pass** (729 + 36). `py_compile` clean.

Hardware:

```
DMP: 2560 records in 72.1s — the full archive, 512 pages, every CRC valid
     spanned 2026-07-30 23:13 .. 2026-08-01 17:52
     outside temp range 20.7 .. 68.0 C

Cross-check: DMPAFT(last 2h) = 119 records
             DMP filtered    = 116 records
```

The 3-record difference is **correct behaviour**: DMP took 72 s to transfer, and at a 1-minute archive interval the console wrote new records during it, which DMPAFT then saw when it ran afterward.

```
PUTRAIN conversion: 630.68mm -> 2483 clicks on the 0.01" collector,
matching the manual's own "PUTRAIN 2483" example for 24.83 inches
```

PUTRAIN/PUTET were **not fired** — they overwrite yearly totals on a live station. Conversion verified against the manual's worked example instead.

## Incidental

The archive still contains the 68.0 °C spike from the failed OAT sensor. `CLRHIGHS` (#224) cleared the console's *high registers*, not stored archive records — different things, worth knowing if that value resurfaces in a chart.

Ref #221