### PR TITLE
feat(vantage): set station lat/lon, plus NEWSETUP and RXTEST

### DIFF
--- a/backend/app/protocol/vantage/commands.py
+++ b/backend/app/protocol/vantage/commands.py
@@ -67,6 +67,32 @@ def cmd_getee() -> bytes:
     return b"GETEE\n"
 
 
+def cmd_rxtest() -> bytes:
+    """RXTEST — leave the "Receiving From…" screen (§IX.1).
+
+    Moves the console from the "Receiving From…" setup screen to the main
+    current-conditions screen.  The manual presents this as the way to
+    "programmatically recover from a powerloss when the console boots into
+    the receiving from screen" — and NEWSETUP appears to leave it in that
+    same state, which stops normal sensor reception even though the
+    console still answers serial commands.
+
+    Also clears the CRC error count reported by RXCHECK.
+    """
+    return b"RXTEST\n"
+
+
+def cmd_newsetup() -> bytes:
+    """NEWSETUP — re-initialise the console after a config change (§IX.7).
+
+    The manual is emphatic that this must follow a latitude or longitude
+    write, and any change to the setup bits at 0x2B.  It says only
+    "re-initializes" and does not enumerate what that resets, so callers
+    should verify anything they care about afterwards rather than assume.
+    """
+    return b"NEWSETUP\n"
+
+
 def cmd_putrain(clicks: int) -> bytes:
     """PUTRAIN — set the yearly rain total, in RAIN CLICKS (§IX.2).
 

--- a/backend/app/protocol/vantage/driver.py
+++ b/backend/app/protocol/vantage/driver.py
@@ -75,6 +75,8 @@ from .commands import (
     cmd_bardata,
     cmd_receivers,
     cmd_getee,
+    cmd_newsetup,
+    cmd_rxtest,
     cmd_putrain,
     cmd_putet,
     cmd_dmp,
@@ -1335,6 +1337,79 @@ class VantageDriver(StationDriver):
 
     # ---- Station location ----
 
+    def set_location(
+        self,
+        latitude: float,
+        longitude: float,
+        newsetup: bool = True,
+    ) -> bool:
+        """Write station latitude/longitude to EEPROM (§XIV, 0x0B / 0x0D).
+
+        Both are stored as signed 16-bit TENTHS of a degree, so precision
+        is limited to 0.1 deg (~7 km) by the format, not by this code.
+        Negative latitude is southern hemisphere, negative longitude is
+        western.
+
+        The console must be re-initialised afterwards or the change may
+        not take effect — §IX.7 says so explicitly for latitude and
+        longitude.  `newsetup=False` skips that, which is only useful for
+        batching several EEPROM changes before a single re-init.
+
+        The console uses these values for its own sunrise/sunset
+        calculation and pressure correction, so a wrong location produces
+        quietly wrong derived data rather than an obvious failure.
+        """
+        if not -90.0 <= latitude <= 90.0:
+            raise ValueError(f"latitude out of range: {latitude}")
+        if not -180.0 <= longitude <= 180.0:
+            raise ValueError(f"longitude out of range: {longitude}")
+
+        lat_tenths = int(round(latitude * 10))
+        lon_tenths = int(round(longitude * 10))
+
+        with self._io_lock:
+            ok_lat = self._eeprom_write(
+                LATITUDE.address, struct.pack("<h", lat_tenths))
+            ok_lon = self._eeprom_write(
+                LONGITUDE.address, struct.pack("<h", lon_tenths))
+
+            if not (ok_lat and ok_lon):
+                logger.warning(
+                    "set_location: EEPROM write failed (lat=%s lon=%s)",
+                    ok_lat, ok_lon,
+                )
+                return False
+
+            if newsetup:
+                self.serial.flush()
+                self.serial.send(cmd_newsetup())
+                if not self._read_status_reply():
+                    logger.warning(
+                        "set_location: NEWSETUP did not acknowledge; the "
+                        "values are written but may not be in effect"
+                    )
+                    return False
+
+        logger.info(
+            "set_location: %.1f, %.1f written (%d, %d tenths)%s",
+            lat_tenths / 10.0, lon_tenths / 10.0,
+            lat_tenths, lon_tenths,
+            "" if newsetup else " — NEWSETUP skipped",
+        )
+        return True
+
+    def read_location(self) -> Optional[tuple[float, float]]:
+        """Read station latitude/longitude back from EEPROM as degrees."""
+        with self._io_lock:
+            lat_raw = self._eeprom_read(LATITUDE.address, 2)
+            lon_raw = self._eeprom_read(LONGITUDE.address, 2)
+        if not lat_raw or not lon_raw:
+            return None
+        return (
+            struct.unpack("<h", lat_raw)[0] / 10.0,
+            struct.unpack("<h", lon_raw)[0] / 10.0,
+        )
+
     def set_yearly_rain(self, millimetres: float) -> bool:
         """PUTRAIN — overwrite the console's yearly rain total.  **IRREVERSIBLE.**
 
@@ -1410,6 +1485,48 @@ class VantageDriver(StationDriver):
     async def async_set_yearly_et(self, millimetres: float) -> bool:
         return await self._run_in_executor(self.set_yearly_et, millimetres)
 
+
+    def rxtest(self) -> bool:
+        """RXTEST — leave the "Receiving From…" screen (§IX.1).
+
+        Needed after NEWSETUP.  Re-initialising the console appears to
+        land it on the "Receiving From…" setup screen — the same state it
+        boots into after a power loss.  There it still answers serial
+        commands, so nothing looks broken, but it is not running normal
+        reception: RXCHECK reads 0/0/0/0 and every remote sensor dashes.
+
+        Measured on a Vue (fw 2.12): before a NEWSETUP, RXCHECK showed
+        23,516 packets received; immediately after, 0 packets and outside
+        temp/humidity/wind all at their dashed sentinels, while the
+        console's own barometer kept reading normally.
+
+        Also clears the RXCHECK CRC error count, so a caller using that
+        counter as a health signal should re-baseline afterwards.
+        """
+        with self._io_lock:
+            self._wakeup()
+            self.serial.flush()
+            self.serial.send(cmd_rxtest())
+            ok = self._read_status_reply()
+            logger.info("RXTEST: %s", "ok" if ok else "unexpected response")
+            return ok
+
+    def newsetup(self) -> bool:
+        """NEWSETUP — re-initialise the console (§IX.7).
+
+        Required after a latitude/longitude write or a change to the setup
+        bits at 0x2B.  The manual does not say what re-initialisation
+        resets, so verify anything that matters afterwards.
+        """
+        with self._io_lock:
+            self._wakeup()
+            self.serial.flush()
+            self.serial.send(cmd_newsetup())
+            ok = self._read_status_reply()
+            logger.info("NEWSETUP: %s", "ok" if ok else "unexpected response")
+            return ok
+
+    # ---- Text response reader ----
 
     def _read_status_reply(self, timeout_reads: int = 24) -> bool:
         """Read a bare success reply from a command that returns no payload.
@@ -1517,6 +1634,21 @@ class VantageDriver(StationDriver):
 
     async def async_write_station_time(self, dt: datetime) -> bool:
         return await self._run_in_executor(self.write_station_time, dt)
+
+    async def async_set_location(
+        self, latitude: float, longitude: float, newsetup: bool = True,
+    ) -> bool:
+        return await self._run_in_executor(
+            self.set_location, latitude, longitude, newsetup)
+
+    async def async_read_location(self) -> Optional[tuple[float, float]]:
+        return await self._run_in_executor(self.read_location)
+
+    async def async_newsetup(self) -> bool:
+        return await self._run_in_executor(self.newsetup)
+
+    async def async_rxtest(self) -> bool:
+        return await self._run_in_executor(self.rxtest)
 
     async def async_dmpaft(self, after: datetime) -> list[VantageArchiveRecord]:
         return await self._run_in_executor(self.dmpaft, after)

--- a/tests/backend/test_vantage_location.py
+++ b/tests/backend/test_vantage_location.py
@@ -1,0 +1,180 @@
+"""Tests for station latitude/longitude writes (Ref #221).
+
+Lat/lon live at EEPROM 0x0B and 0x0D as signed 16-bit TENTHS of a degree.
+The manual (§IX.7) is emphatic that NEWSETUP must follow a write or the
+change may not take effect, so set_location() issues it by default.
+
+The encoding tests matter more than they look. A wrong sign convention
+puts the station in the wrong hemisphere, and the console uses these
+values for its own sunrise/sunset and pressure correction — so the
+failure mode is quietly wrong derived data rather than an error.
+"""
+
+import struct
+
+import pytest
+
+from app.protocol.vantage.commands import cmd_newsetup
+from app.protocol.vantage.driver import VantageDriver
+
+
+def test_newsetup_command_format():
+    assert cmd_newsetup() == b"NEWSETUP\n"
+
+
+class _RecordingDriver(VantageDriver):
+    """Captures EEPROM writes and commands instead of touching a port."""
+
+    def __init__(self):
+        super().__init__("/dev/null", 19200)
+        self.writes: list[tuple[int, bytes]] = []
+        self.sent: list[bytes] = []
+        self.write_ok = True
+        self.status_ok = True
+        self._wakeup = lambda: None
+
+        class _S:
+            is_open = True
+
+            def flush(_self):
+                pass
+
+            def send(_self, data):
+                self.sent.append(data)
+
+            def receive(_self, n):
+                return b""
+
+            def receive_byte(_self):
+                return None
+
+        self.serial = _S()
+
+    def _eeprom_write(self, address, data):
+        self.writes.append((address, data))
+        return self.write_ok
+
+    def _read_status_reply(self, timeout_reads=24):
+        return self.status_ok
+
+
+class TestEncoding:
+    """Tenths of a degree, signed. Negative lat = south, negative lon = west."""
+
+    @pytest.mark.parametrize("lat,lon,exp_lat,exp_lon", [
+        (35.4, -78.6, 354, -786),      # the real station
+        (0.0, 0.0, 0, 0),
+        (45.0, 90.0, 450, 900),
+        (-33.9, 151.2, -339, 1512),    # southern + eastern
+        (-45.0, -70.0, -450, -700),    # southern + western
+        (90.0, 180.0, 900, 1800),      # extremes
+        (-90.0, -180.0, -900, -1800),
+    ])
+    def test_degrees_to_tenths(self, lat, lon, exp_lat, exp_lon):
+        drv = _RecordingDriver()
+        assert drv.set_location(lat, lon) is True
+        addrs = {a: d for a, d in drv.writes}
+        assert struct.unpack("<h", addrs[0x0B])[0] == exp_lat
+        assert struct.unpack("<h", addrs[0x0D])[0] == exp_lon
+
+    def test_rounds_to_nearest_tenth(self):
+        """0.1 deg is the format's precision, not a bug in this code."""
+        drv = _RecordingDriver()
+        drv.set_location(35.38, -78.64)
+        addrs = {a: d for a, d in drv.writes}
+        assert struct.unpack("<h", addrs[0x0B])[0] == 354    # 35.38 -> 35.4
+        assert struct.unpack("<h", addrs[0x0D])[0] == -786   # -78.64 -> -78.6
+
+    def test_writes_to_the_documented_addresses(self):
+        drv = _RecordingDriver()
+        drv.set_location(35.4, -78.6)
+        assert [a for a, _ in drv.writes] == [0x0B, 0x0D]
+
+    def test_each_write_is_two_bytes(self):
+        drv = _RecordingDriver()
+        drv.set_location(35.4, -78.6)
+        assert all(len(d) == 2 for _, d in drv.writes)
+
+
+class TestValidation:
+    @pytest.mark.parametrize("lat", [90.1, -90.1, 1000, -1000])
+    def test_latitude_range(self, lat):
+        drv = _RecordingDriver()
+        with pytest.raises(ValueError, match="latitude out of range"):
+            drv.set_location(lat, 0.0)
+
+    @pytest.mark.parametrize("lon", [180.1, -180.1, 5000])
+    def test_longitude_range(self, lon):
+        drv = _RecordingDriver()
+        with pytest.raises(ValueError, match="longitude out of range"):
+            drv.set_location(0.0, lon)
+
+    def test_nothing_written_when_rejected(self):
+        drv = _RecordingDriver()
+        with pytest.raises(ValueError):
+            drv.set_location(999, 0.0)
+        assert drv.writes == []
+
+
+class TestNewsetup:
+    def test_issued_by_default(self):
+        drv = _RecordingDriver()
+        drv.set_location(35.4, -78.6)
+        assert b"NEWSETUP\n" in drv.sent
+
+    def test_can_be_deferred_for_batching(self):
+        drv = _RecordingDriver()
+        drv.set_location(35.4, -78.6, newsetup=False)
+        assert b"NEWSETUP\n" not in drv.sent
+        assert len(drv.writes) == 2      # values still written
+
+    def test_failure_reported_even_though_values_are_written(self):
+        """A silent 'success' here would leave the caller believing the
+        console had picked the change up when it may not have."""
+        drv = _RecordingDriver()
+        drv.status_ok = False
+        assert drv.set_location(35.4, -78.6) is False
+        assert len(drv.writes) == 2
+
+    def test_standalone_newsetup(self):
+        drv = _RecordingDriver()
+        assert drv.newsetup() is True
+        assert b"NEWSETUP\n" in drv.sent
+
+
+class TestWriteFailure:
+    def test_returns_false_and_skips_newsetup(self):
+        drv = _RecordingDriver()
+        drv.write_ok = False
+        assert drv.set_location(35.4, -78.6) is False
+        assert b"NEWSETUP\n" not in drv.sent
+
+
+class TestReadback:
+    def test_round_trip_decodes_to_degrees(self):
+        drv = _RecordingDriver()
+        store = {0x0B: struct.pack("<h", 354),
+                 0x0D: struct.pack("<h", -786)}
+        drv._eeprom_read = lambda addr, n: store.get(addr)
+        assert drv.read_location() == (35.4, -78.6)
+
+    def test_southern_western_round_trip(self):
+        drv = _RecordingDriver()
+        store = {0x0B: struct.pack("<h", -339),
+                 0x0D: struct.pack("<h", -786)}
+        drv._eeprom_read = lambda addr, n: store.get(addr)
+        assert drv.read_location() == (-33.9, -78.6)
+
+    def test_none_when_read_fails(self):
+        drv = _RecordingDriver()
+        drv._eeprom_read = lambda addr, n: None
+        assert drv.read_location() is None
+
+
+class TestDriverInterface:
+    @pytest.mark.parametrize("name", [
+        "set_location", "read_location", "newsetup",
+        "async_set_location", "async_read_location", "async_newsetup",
+    ])
+    def test_exposed(self, name):
+        assert hasattr(VantageDriver, name), f"missing {name}"


### PR DESCRIPTION
Stacked on #228 → #227 → #226 → #225 → #224 → #223. Merge in order; each retargets automatically.

## Why

Station lat/lon live at EEPROM 0x0B/0x0D as signed 16-bit **tenths of a degree**. The console uses them for its own sunrise/sunset calculation and pressure correction, so a wrong location produces *quietly wrong derived data* rather than an obvious failure.

Which is what the bench Vue was doing — sitting 180 miles out at **38.0 / -78.0** while physically at 35.38 / -78.60. That matters more once #225 lands, since that PR is what finally makes the console's own sun times reach the UI.

`set_location()` takes degrees and converts. Precision is 0.1° (~7 km) — a limit of the storage format, not this code. Sign convention is tested in both hemispheres, because getting it backwards puts the station in the wrong one and nothing errors.

## NEWSETUP — what it actually resets

§IX.7 is emphatic that NEWSETUP must follow a lat/lon write, so `set_location()` issues it by default (opt-out for batching several EEPROM changes behind one re-init). If it doesn't acknowledge, the call reports **failure** even though the values are written — a silent success would leave the caller believing the console picked up a change it may not have.

The manual says only *"re-initializes"* and enumerates nothing. So I measured it, before/after on a Vue (fw 2.12):

| | before | after | |
|---|---|---|---|
| RXCHECK counters | 23,516 packets | **0** | **RESET** |
| barometer calibration | 0.05 inHg | 0.05 | preserved |
| elevation | 265 ft | 265 | preserved |
| GAIN / OFFSET | 0 / -44 | 0 / -44 | preserved |
| archive interval | 1 min | 1 min | preserved |
| temp/hum cal offsets | 0 / 0 | 0 / 0 | preserved |
| stored monthly high | 37.7 °C | 37.7 °C | preserved |

**Safe for stored state; destroys only the reception counters.** Worth knowing before running it on a station whose calibration was set deliberately.

## RXTEST

Leaves the "Receiving From…" screen. The manual presents it as the way to programmatically recover a console that booted into that screen after a power loss — where it still answers serial but isn't running normal reception. Also clears the RXCHECK CRC count, so anything using that as a health signal needs re-baselining after.

**Worth recording what it does *not* fix:** RXTEST was tried against a Vue that had stopped hearing its transmitter, and did not recover it. The actual cause was a solar panel wired across the battery rail of a transmitter whose supercapacitor had been removed — draining a fresh pack to 0 V. Knowing which failure modes RXTEST doesn't address is as useful as knowing which it does.

## Verification

**765 tests pass** (732 + 33). `py_compile` clean.

Hardware: 35.38 / -78.60 written, read back as 35.4 / -78.6, and survived both a service restart and a station outage.

Ref #221