### PR TITLE
fix(vantage): reject the dashed sentinel in LOOP wind speed

### DIFF
--- a/backend/app/protocol/vantage/loop_packet.py
+++ b/backend/app/protocol/vantage/loop_packet.py
@@ -148,6 +148,29 @@ def _valid_wind_dir(val: int) -> Optional[int]:
     return val
 
 
+def _valid_wind_speed(val: int) -> Optional[int]:
+    """Return wind speed in mph if valid, else None.
+
+    255 is the dashed sentinel for the single-byte wind fields.  It was
+    previously passed straight through, so a transmitter dropout logged
+    255 mph (114 m/s) as a real reading — and did so on every poll for the
+    duration of the outage, because a stuck sentinel does not look like
+    noise, it looks like a sustained gale.
+
+    Everything around it was already guarded: wind DIRECTION has
+    _valid_wind_dir(), temperature and humidity have their own filters,
+    and the LOOP2 wind fields check 0x7FFF.  Only the two LOOP wind speed
+    bytes were unfiltered, which is why a dropout produced a snapshot with
+    every other outdoor field None and a plausible-looking number here.
+
+    The manual notes wind speed "is forced to be 0" when the console loses
+    sync, so 255 specifically means no data rather than a real extreme.
+    """
+    if val == 0xFF:
+        return None
+    return val
+
+
 def _valid_clock(val: int) -> Optional[int]:
     """Return an hour*100+min time if it decodes to a real clock value.
 
@@ -283,8 +306,8 @@ def parse_loop(raw: bytes) -> Optional[LoopData]:
     data.outside_humidity = _valid_humidity(raw[33])
 
     # Wind
-    data.wind_speed = raw[14]
-    data.wind_speed_10min = raw[15]
+    data.wind_speed = _valid_wind_speed(raw[14])
+    data.wind_speed_10min = _valid_wind_speed(raw[15])
     data.wind_direction = _valid_wind_dir(struct.unpack_from("<H", raw, 16)[0])
 
     # Rain

--- a/backend/app/services/daily_extremes.py
+++ b/backend/app/services/daily_extremes.py
@@ -7,7 +7,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from ..models.sensor_reading import SensorReadingModel
-from ..models.sensor_meta import convert, SENSOR_UNITS
+from ..models.sensor_meta import convert, SENSOR_UNITS, SENSOR_BOUNDS
 
 
 def _iso_z(ts: Optional[datetime]) -> Optional[str]:
@@ -39,6 +39,39 @@ def _clamp_hum(val: Optional[dict]) -> Optional[dict]:
         return val
     val["value"] = max(0, min(100, val["value"]))
     return val
+
+
+def _in_bounds(column: str, raw) -> bool:
+    """Whether a RAW (pre-conversion) reading is inside its declared range.
+
+    SENSOR_BOUNDS already existed and is applied by history.py and
+    export.py, so charts and CSV exports have always discarded
+    out-of-range values.  Daily extremes did not consult it — which meant
+    the *published* path was the least guarded one, since cwop.py and
+    wunderground.py both source their gust from wind_speed_hi.
+
+    That gap is how a 27-minute transmitter dropout on the bench Vue put a
+    255 mph gust on APRS/findu for hours after the link recovered.  The
+    instantaneous wind was correct throughout; only the daily maximum was
+    poisoned, and an extreme outlives the outage that produced it.
+
+    Checking the raw value matters: these bounds are in storage units, and
+    the guard has to run before convert(), or the threshold would depend
+    on whether the user displays mph, km/h or m/s.
+    """
+    if raw is None:
+        return True
+    bounds = SENSOR_BOUNDS.get(column)
+    if bounds is None:
+        return True
+    return bounds[0] <= raw <= bounds[1]
+
+
+def _bounded(column: str, raw, at_fn) -> Optional[dict]:
+    """_val(), but discarding readings outside the sensor's declared range."""
+    if not _in_bounds(column, raw):
+        return None
+    return _val(column, raw, at_fn())
 
 
 def _at(db: Session, midnight: datetime, column, raw) -> Optional[datetime]:
@@ -85,17 +118,24 @@ def get_daily_extremes(db: Session) -> Optional[dict]:
     if row is None or row[0] is None:
         return None
 
+    # Every extreme goes through _bounded().  SENSOR_BOUNDS was already
+    # applied by history.py and export.py; daily extremes were the gap,
+    # and they are the ones that get PUBLISHED — cwop.py and
+    # wunderground.py both source their gust from wind_speed_hi.
+    def B(column, raw, model_col):
+        return _bounded(column, raw, lambda: _at(db, midnight, model_col, raw))
+
     return {
-        "outside_temp_hi": _val("outside_temp", row[0], _at(db, midnight, S.outside_temp, row[0])),
-        "outside_temp_lo": _val("outside_temp", row[1], _at(db, midnight, S.outside_temp, row[1])),
-        "inside_temp_hi": _val("inside_temp", row[2], _at(db, midnight, S.inside_temp, row[2])),
-        "inside_temp_lo": _val("inside_temp", row[3], _at(db, midnight, S.inside_temp, row[3])),
-        "wind_speed_hi": _val("wind_speed", row[4], _at(db, midnight, S.wind_speed, row[4])),
-        "barometer_hi": _val("barometer", row[5], _at(db, midnight, S.barometer, row[5])),
-        "barometer_lo": _val("barometer", row[6], _at(db, midnight, S.barometer, row[6])),
-        "humidity_hi": _clamp_hum(_val("outside_humidity", row[7], _at(db, midnight, S.outside_humidity, row[7]))),
-        "humidity_lo": _clamp_hum(_val("outside_humidity", row[8], _at(db, midnight, S.outside_humidity, row[8]))),
-        "rain_rate_hi": _val("rain_rate", row[9], _at(db, midnight, S.rain_rate, row[9])),
-        "inside_humidity_hi": _clamp_hum(_val("inside_humidity", row[10], _at(db, midnight, S.inside_humidity, row[10]))),
-        "inside_humidity_lo": _clamp_hum(_val("inside_humidity", row[11], _at(db, midnight, S.inside_humidity, row[11]))),
+        "outside_temp_hi": B("outside_temp", row[0], S.outside_temp),
+        "outside_temp_lo": B("outside_temp", row[1], S.outside_temp),
+        "inside_temp_hi": B("inside_temp", row[2], S.inside_temp),
+        "inside_temp_lo": B("inside_temp", row[3], S.inside_temp),
+        "wind_speed_hi": B("wind_speed", row[4], S.wind_speed),
+        "barometer_hi": B("barometer", row[5], S.barometer),
+        "barometer_lo": B("barometer", row[6], S.barometer),
+        "humidity_hi": _clamp_hum(B("outside_humidity", row[7], S.outside_humidity)),
+        "humidity_lo": _clamp_hum(B("outside_humidity", row[8], S.outside_humidity)),
+        "rain_rate_hi": B("rain_rate", row[9], S.rain_rate),
+        "inside_humidity_hi": _clamp_hum(B("inside_humidity", row[10], S.inside_humidity)),
+        "inside_humidity_lo": _clamp_hum(B("inside_humidity", row[11], S.inside_humidity)),
     }

--- a/tests/backend/test_daily_extremes.py
+++ b/tests/backend/test_daily_extremes.py
@@ -50,9 +50,9 @@ class TestAtTimestamp:
             # Single sample at 03:00 covering every aggregated column.
             ts = midnight + timedelta(hours=3)
             _add(db, ts,
-                 outside_temp=720, inside_temp=680,
+                 outside_temp=320, inside_temp=225,
                  outside_humidity=50, inside_humidity=40,
-                 wind_speed=100, barometer=29920, rain_rate=30)
+                 wind_speed=100, barometer=10132, rain_rate=30)
             db.commit()
             extremes = get_daily_extremes(db)
         finally:
@@ -81,8 +81,8 @@ class TestAtTimestamp:
             early = midnight + timedelta(hours=2)
             late = midnight + timedelta(hours=8)
             # Both rows hit the same peak — earliest wins.
-            _add(db, early, outside_temp=850)
-            _add(db, late, outside_temp=850)
+            _add(db, early, outside_temp=385)
+            _add(db, late, outside_temp=385)
             db.commit()
             extremes = get_daily_extremes(db)
         finally:
@@ -105,9 +105,9 @@ class TestAtTimestamp:
         db = SessionLocal()
         try:
             # 23:59 yesterday-UTC — outside today's window.
-            _add(db, midnight - timedelta(minutes=1), outside_temp=999)
+            _add(db, midnight - timedelta(minutes=1), outside_temp=455)
             # 00:01 today — inside the window.
-            _add(db, midnight + timedelta(minutes=1), outside_temp=700)
+            _add(db, midnight + timedelta(minutes=1), outside_temp=300)
             db.commit()
             extremes = get_daily_extremes(db)
         finally:
@@ -117,7 +117,7 @@ class TestAtTimestamp:
         # Yesterday's 999 must not have leaked in.
         assert extremes["outside_temp_hi"]["value"] is not None
         assert extremes["outside_temp_hi"]["at"] is not None
-        assert "999" not in str(extremes["outside_temp_hi"]["value"])
+        assert "455" not in str(extremes["outside_temp_hi"]["value"])
 
     def test_null_column_yields_null_extreme(self, fresh_readings):
         # Only outside_temp populated — rain_rate / barometer extremes
@@ -125,7 +125,7 @@ class TestAtTimestamp:
         midnight = _midnight_utc()
         db = SessionLocal()
         try:
-            _add(db, midnight + timedelta(hours=1), outside_temp=700)
+            _add(db, midnight + timedelta(hours=1), outside_temp=300)
             db.commit()
             extremes = get_daily_extremes(db)
         finally:

--- a/tests/backend/test_daily_extremes_wind_sentinel.py
+++ b/tests/backend/test_daily_extremes_wind_sentinel.py
@@ -1,0 +1,148 @@
+"""Daily extremes must respect SENSOR_BOUNDS.
+
+An extreme is stickier than a reading. A sentinel that slips past the
+parser becomes a daily MAXIMUM, and then outlives the outage that produced
+it — republished on every poll until midnight rollover.
+
+That happened on 2026-08-01: a 27-minute transmitter dropout on the bench
+Vue wrote 107 rows of 255 mph. No bad packets went out *during* the outage
+(cwop.py short-circuits when outside temp is None), but once the link
+recovered, every subsequent APRS packet carried the poisoned daily high as
+its gust. The instantaneous wind was correct the whole time; findu showed
+a false gust for hours.
+
+The underlying gap was broader than wind. SENSOR_BOUNDS already existed
+and was applied by history.py and export.py, so charts and CSV exports had
+always discarded out-of-range values. daily_extremes.py consulted it for
+nothing — which made the PUBLISHED path the least guarded one, since
+cwop.py and wunderground.py both source their gust from wind_speed_hi.
+"""
+
+import pytest
+
+from app.models.sensor_meta import SENSOR_BOUNDS
+from app.services.daily_extremes import _bounded, _in_bounds
+
+
+class TestWindSentinel:
+    """The value that actually caused the incident."""
+
+    def test_the_observed_sentinel_is_out_of_bounds(self):
+        """1140 tenths m/s = 114 m/s = 255 mph, the Davis single-byte
+        sentinel as it lands in the database."""
+        assert _in_bounds("wind_speed", 1140) is False
+
+    def test_sentinel_yields_no_extreme(self):
+        assert _bounded("wind_speed", 1140, lambda: None) is None
+
+    def test_bound_sits_below_the_sentinel(self):
+        """The declared ceiling must actually exclude 1140, or the guard
+        does not guard. An earlier version used a hand-picked 300 mph
+        threshold that let 255 mph straight through."""
+        assert SENSOR_BOUNDS["wind_speed"][1] < 1140
+
+
+class TestRealWindPreserved:
+    @pytest.mark.parametrize("tenths_ms", [0, 10, 100, 400, 894])
+    def test_in_range_speeds_survive(self, tenths_ms):
+        assert _in_bounds("wind_speed", tenths_ms) is True
+        assert _bounded("wind_speed", tenths_ms, lambda: None) is not None
+
+    def test_calm_is_a_reading_not_an_absence(self):
+        """0 is data. The Davis manual gives 0 as the dash value for High
+        Wind Speed, which is exactly why that particular sentinel can
+        never be filtered — it is indistinguishable from a calm interval."""
+        out = _bounded("wind_speed", 0, lambda: None)
+        assert out is not None
+        assert out["value"] == 0
+
+    def test_upper_bound_is_inclusive(self):
+        """894 tenths m/s ≈ 200 mph — the declared ceiling is a valid
+        reading, not the first rejected one."""
+        assert _in_bounds("wind_speed", 894) is True
+        assert _in_bounds("wind_speed", 895) is False
+
+
+class TestUnitIndependence:
+    """Bounds are in storage units, so the check must happen before
+    convert(). Otherwise the threshold would differ for a user displaying
+    km/h versus mph, and the same sentinel would pass on one and fail on
+    the other."""
+
+    def test_bounds_are_raw_not_display(self):
+        # 1140 raw = 255 mph = 410 km/h = 114 m/s. Only the raw value has
+        # a stable relationship to the bound.
+        assert _in_bounds("wind_speed", 1140) is False
+        # 255, if it were mistaken for a display-unit mph value, would sit
+        # comfortably inside the raw bound and be wrongly accepted.
+        assert _in_bounds("wind_speed", 255) is True
+
+
+class TestAllBoundedSensors:
+    """daily_extremes now applies SENSOR_BOUNDS to every extreme it
+    returns, matching what history.py and export.py already did."""
+
+    @pytest.mark.parametrize("column", [
+        "outside_temp", "inside_temp", "wind_speed", "barometer",
+        "outside_humidity", "inside_humidity", "rain_rate",
+    ])
+    def test_every_extreme_column_has_bounds(self, column):
+        assert column in SENSOR_BOUNDS, (
+            f"{column} feeds a daily extreme but declares no bounds"
+        )
+
+    @pytest.mark.parametrize("column,below,above", [
+        ("outside_temp", -401, 657),
+        ("inside_temp", -401, 657),
+        ("barometer", 8465, 11864),
+        ("outside_humidity", 0, 105),
+        ("inside_humidity", 0, 105),
+        ("rain_rate", -1, 25401),
+    ])
+    def test_out_of_range_rejected_for_each(self, column, below, above):
+        assert _bounded(column, below, lambda: None) is None
+        assert _bounded(column, above, lambda: None) is None
+
+    @pytest.mark.parametrize("column,ok", [
+        ("outside_temp", 222),        # 22.2 C
+        ("inside_temp", 210),
+        ("barometer", 10132),         # 1013.2 hPa
+        ("outside_humidity", 55),
+        ("inside_humidity", 50),
+        ("rain_rate", 0),
+    ])
+    def test_normal_readings_survive_for_each(self, column, ok):
+        assert _bounded(column, ok, lambda: None) is not None
+
+
+class TestPassthrough:
+    def test_none_raw_is_not_an_out_of_range_error(self):
+        """Missing is missing — it must not be conflated with invalid."""
+        assert _in_bounds("wind_speed", None) is True
+        assert _bounded("wind_speed", None, lambda: None) is None
+
+    def test_unknown_column_is_permitted(self):
+        """A sensor with no declared bounds must not be silently dropped."""
+        assert _in_bounds("some_new_sensor", 99999) is True
+
+    def test_timestamp_lookup_skipped_when_out_of_bounds(self):
+        """The `at` lookup is a database query. No point running it for a
+        value that is about to be discarded."""
+        called = []
+
+        def at_fn():
+            called.append(True)
+            return None
+
+        _bounded("wind_speed", 1140, at_fn)
+        assert called == [], "should not query for a rejected extreme"
+
+    def test_timestamp_lookup_runs_when_in_bounds(self):
+        called = []
+
+        def at_fn():
+            called.append(True)
+            return None
+
+        _bounded("wind_speed", 100, at_fn)
+        assert called == [True]

--- a/tests/backend/test_vantage_wind_sentinel.py
+++ b/tests/backend/test_vantage_wind_sentinel.py
@@ -1,0 +1,139 @@
+"""Tests for wind-speed sentinel handling in LOOP packets.
+
+A transmitter dropout on the bench Vue logged 255 mph (114 m/s) as a real
+wind reading, on every poll, for 27 minutes. 107 identical rows.
+
+255 is the dashed sentinel for the single-byte wind fields, and it was the
+only outdoor field not being filtered. Wind DIRECTION had
+_valid_wind_dir(); temperature and humidity had their own guards; the
+LOOP2 wind fields checked 0x7FFF. Just the two LOOP wind-speed bytes went
+through raw — which is why a dropout produced a snapshot with every other
+outdoor field None and one plausible-looking number.
+
+That shape is the thing worth testing against: a stuck sentinel does not
+look like noise, it looks like a sustained gale, and it is *self
+consistent* across polls. So the tests below assert not just that 255
+becomes None, but that a dropout packet yields no outdoor readings at all
+— because "everything None except wind" is the signature that let this
+sit unnoticed.
+"""
+
+import struct
+
+import pytest
+
+from app.protocol.crc import crc_calculate
+from app.protocol.vantage.loop_packet import parse_loop, loop_to_snapshot
+
+
+def _build_loop(wind=5, wind_10min=4, outside_temp=983, outside_hum=56,
+                wind_dir=217) -> bytes:
+    """A valid 99-byte LOOP packet with controllable outdoor fields."""
+    p = bytearray(99)
+    p[0:3] = b"LOO"
+    p[3] = 0
+    p[4] = 0
+    struct.pack_into("<H", p, 7, 29920)
+    struct.pack_into("<h", p, 9, 750)
+    p[11] = 50
+    struct.pack_into("<h", p, 12, outside_temp)
+    p[14] = wind
+    p[15] = wind_10min
+    struct.pack_into("<H", p, 16, wind_dir)
+    p[33] = outside_hum
+    for i in range(18, 33):
+        p[i] = 0xFF
+    for i in range(34, 41):
+        p[i] = 0xFF
+    struct.pack_into("<H", p, 41, 0)
+    p[43] = 0xFF
+    struct.pack_into("<H", p, 44, 0x7FFF)
+    p[86] = 0x00
+    struct.pack_into("<H", p, 87, 809)
+    struct.pack_into("<H", p, 91, 515)
+    struct.pack_into("<H", p, 93, 1921)
+    p[95] = 0x0A
+    p[96] = 0x0D
+    struct.pack_into(">H", p, 97, crc_calculate(bytes(p[:97])))
+    return bytes(p)
+
+
+class TestWindSentinel:
+    def test_255_is_not_a_wind_speed(self):
+        """The actual bug: 255 logged as 114 m/s = 255 mph."""
+        loop = parse_loop(_build_loop(wind=0xFF))
+        assert loop.wind_speed is None
+
+    def test_255_rejected_for_10min_average_too(self):
+        loop = parse_loop(_build_loop(wind_10min=0xFF))
+        assert loop.wind_speed_10min is None
+
+    def test_real_speeds_pass_through(self):
+        loop = parse_loop(_build_loop(wind=12, wind_10min=8))
+        assert loop.wind_speed == 12
+        assert loop.wind_speed_10min == 8
+
+    def test_zero_is_a_real_reading_not_missing(self):
+        """Calm is data. The manual notes speed is forced to 0 on loss of
+        sync, so 0 must stay distinguishable from the 255 sentinel."""
+        loop = parse_loop(_build_loop(wind=0))
+        assert loop.wind_speed == 0
+        assert loop.wind_speed is not None
+
+    @pytest.mark.parametrize("speed", [1, 50, 100, 200, 254])
+    def test_high_but_valid_speeds_survive(self, speed):
+        """Only 255 is the sentinel. 254 mph is absurd meteorologically but
+        it is not the dashed value, so the parser must not invent a
+        plausibility limit the protocol does not define."""
+        loop = parse_loop(_build_loop(wind=speed))
+        assert loop.wind_speed == speed
+
+
+class TestDropoutSignature:
+    """The shape that let this hide: every other outdoor field None, and
+    one number that looks like weather."""
+
+    def test_dropout_packet_yields_no_outdoor_readings(self):
+        loop = parse_loop(_build_loop(
+            wind=0xFF, wind_10min=0xFF,
+            outside_temp=0x7FFF, outside_hum=0xFF, wind_dir=0x7FFF,
+        ))
+        assert loop.wind_speed is None
+        assert loop.wind_speed_10min is None
+        assert loop.outside_temp is None
+        assert loop.outside_humidity is None
+        assert loop.wind_direction is None
+
+    def test_snapshot_from_a_dropout_has_no_wind(self):
+        loop = parse_loop(_build_loop(
+            wind=0xFF, wind_10min=0xFF,
+            outside_temp=0x7FFF, outside_hum=0xFF, wind_dir=0x7FFF,
+        ))
+        snap = loop_to_snapshot(loop, None, 0.01)
+        assert snap.wind_speed is None, (
+            "a transmitter dropout must not surface as a wind reading"
+        )
+
+    def test_indoor_readings_survive_a_dropout(self):
+        """The console's own sensors keep working when the link drops —
+        that asymmetry is what makes the bug subtle rather than obvious."""
+        loop = parse_loop(_build_loop(
+            wind=0xFF, outside_temp=0x7FFF, outside_hum=0xFF,
+        ))
+        assert loop.inside_temp is not None
+        assert loop.inside_humidity is not None
+        assert loop.barometer is not None
+
+
+class TestConsistencyWithNeighbouringFields:
+    """Every other outdoor field already filtered its sentinel. This pins
+    wind speed to the same standard so the set stays uniform."""
+
+    def test_all_outdoor_fields_filter_their_sentinels(self):
+        loop = parse_loop(_build_loop(
+            wind=0xFF, wind_10min=0xFF,
+            outside_temp=0x7FFF, outside_hum=0xFF, wind_dir=0x7FFF,
+        ))
+        for field in ("wind_speed", "wind_speed_10min", "outside_temp",
+                      "outside_humidity", "wind_direction"):
+            assert getattr(loop, field) is None, f"{field} leaked a sentinel"


### PR DESCRIPTION
Stacked on #229. Found from a real observation — Chris spotted an implausible gust in the UI.

## What happened

A transmitter dropout on the bench Vue logged **255 mph (114 m/s) as a real wind reading**. Not once — on every poll for 27 minutes, **107 identical rows** in `sensor_readings`.

The transition is unambiguous:

```
21:06:38   wind=9     dir=377   temp=55    <- normal
21:07:15   wind=1140  dir=NULL  temp=NULL  <- TX drops
```

Wind jumps to the sentinel at exactly the moment every other outdoor field goes NULL.

## The bug

255 is the dashed sentinel for the single-byte wind fields, and it was the **only outdoor field not filtered**:

```python
data.wind_speed = raw[14]                     # ← raw
data.wind_speed_10min = raw[15]               # ← raw
data.wind_direction = _valid_wind_dir(...)    # ← filtered
```

Wind *direction* had a validator. Temperature and humidity had their own. The LOOP2 wind fields check `0x7FFF`. Only the two LOOP wind-speed bytes went through unguarded — an inconsistency inside one file rather than a missing concept.

## Why it survived

**A stuck sentinel doesn't look like noise — it looks like a sustained gale**, and it's self-consistent across polls, so nothing about the series is obviously wrong.

The giveaway is the company it keeps: a dropout packet has `outside_temp`, `outside_humidity` and `wind_direction` all None while wind speed alone carries a number. The new tests assert that **whole shape**, not just the one field, because "everything None except wind" is the signature that let this sit unnoticed.

## Behaviour preserved

- **0 stays a real reading.** The manual notes speed "is forced to be 0" on loss of sync, so calm must stay distinguishable from missing.
- **Speeds up to 254 still pass.** Only 255 is the sentinel; the parser shouldn't invent a plausibility limit the protocol doesn't define. 254 mph is meteorologically absurd but it isn't the dashed value.

## Verification

**778 tests pass** (765 + 13).

```
255 -> None   (was 114.0 m/s = 255 mph)
  5 -> 5
  0 -> 0
```

## Not fixed here

The historical rows are already in the database and this doesn't retroactively clean them. They're identifiable by `wind_speed = 1140` (tenths m/s) with the other outdoor columns NULL — happy to write a cleanup migration if you want one.