### PR TITLE
fix(auth): snapshot auth guard at request time, drop dead cookie check

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -26,16 +26,20 @@ class ApiError extends Error {
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const url = `${API_BASE}${path}`;
+  // Snapshot BEFORE fetch: a request issued while logged out must not eject
+  // the user, regardless of when its 401 arrives.  Reading the flag at
+  // response time races AuthContext.login() setting it to "1", and mount-time
+  // admin calls (/api/auth/me, /api/config via syncUIPrefs) whose 401 lands
+  // after a successful login otherwise bounce the freshly authenticated user
+  // straight back to /login.  See #272.
+  const wasAuthedAtSend = sessionStorage.getItem("knf_was_authed") === "1";
   const response = await fetch(url, {
     ...init,
     credentials: "same-origin",
   });
 
   if (response.status === 401) {
-    // Only redirect to login if the user was previously authenticated.
-    // Many providers call admin endpoints on mount — 401 is expected
-    // when not logged in and those providers handle failure gracefully.
-    if (document.cookie.includes("knf_session") || sessionStorage.getItem("knf_was_authed")) {
+    if (wasAuthedAtSend) {
       window.dispatchEvent(new CustomEvent("kanfei:auth-required"));
     }
     throw new ApiError(401, "Authentication required");


### PR DESCRIPTION
## Summary

Guard hygiene in `frontend/src/api/client.ts` — the 401 handler now snapshots the auth state before `fetch()` returns instead of reading it at response time. Also drops the dead `document.cookie.includes(\"knf_session\")` operand (session cookie has been `httponly=True` since the auth layer landed, so that read is always false).

Ref #272, #286.

## Not the #272 closer

Codex's diagnostic on #272 (2026-08-07) established the observed login flake is a harness lifecycle bug — Playwright's `global-setup.ts` rebuilds `tests/e2e/fixtures/test.db` under a reused uvicorn whose SQLAlchemy `QueuePool` holds stale file handles. Concurrent post-login requests can then fail `validate_session` against the stale inode, return 401, and bounce the user. **#286 tracks the three-PR plan.** PR B (`fix/e2e-rebuild-restarts-server`, coming next) fixes the harness and closes #272.

This PR closes a real but different class: a request truly issued while logged out whose 401 arrives after `AuthContext.login()` sets `sessionStorage.knf_was_authed = \"1\"`. The current guard reads too late — the flag has flipped by the time the response arrives, so `kanfei:auth-required` dispatches on what should be a harmless response. Snapshotting at send time closes that.

## Why the dead cookie check goes

`document.cookie` cannot see a `httponly=True` cookie. That operand was always false. Removing it makes the guard single-source (sessionStorage) rather than misleadingly two-source, and matches what the guard has always actually evaluated.

## The regression test lives with PR B

The natural regression here — hold a mount-time admin GET, log in, release its 401 after the redirect, assert the user stays on `/settings` — requires a working harness to prove the freshly authenticated user is on `/settings` in the first place. Landing that test with this PR would incidentally trip on the unrelated backend flake (measured 3/5 flaky locally). It ships with PR B, once the harness lifecycle no longer poisons the assertion.

## Verification

- [x] `npx tsc --noEmit` clean.
- [x] Full E2E suite: **97/97 pass** locally.
- [x] Bundle inspection: `knf_session` string gone from the built bundle; `knf_was_authed` referenced 3× (guard read + login set + logout clear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)